### PR TITLE
Add regenerate movie threshold to config

### DIFF
--- a/resources/js/HelioviewerWebClient.js
+++ b/resources/js/HelioviewerWebClient.js
@@ -126,7 +126,7 @@ var HelioviewerWebClient = HelioviewerClient.extend(
         this.imageSelectTool = new ImageSelectTool();
 
         this._screenshotManagerUI = new ScreenshotManagerUI();
-        this._movieManagerUI      = new MovieManagerUI();
+        this._movieManagerUI      = new MovieManagerUI(serverSettings.regenerateMovieThreshold);
 
         this._glossary = new VisualGlossary(this._setupDialog);
 

--- a/resources/js/Media/MovieManagerUI.js
+++ b/resources/js/Media/MovieManagerUI.js
@@ -17,9 +17,9 @@ var MovieManagerUI = MediaManagerUI.extend(
      * @constructs
      * Creates a new MovieManagerUI instance
      *
-     * @param {MovieManager} model MovieManager instance
+     * @param {int} regenerateMovieThreshold Number of days to wait before displaying the "regenerate" option on an old movie.
      */
-    init: function (movieManager) {
+    init: function (regenerateMovieThreshold = 90) {
         var movies = Helioviewer.userSettings.get('history.movies');
         this._manager = new MovieManager(movies);
         this._super("movie");
@@ -33,6 +33,7 @@ var MovieManagerUI = MediaManagerUI.extend(
         this._movieLayers = null;
         this._movieEvents = null;
         this._movieEventsLabels = null;
+        this._regenerateMovieThreshold = regenerateMovieThreshold;
         this._initEvents();
         this._initSettings();
 
@@ -592,7 +593,7 @@ var MovieManagerUI = MediaManagerUI.extend(
         movie = this._manager.get(id);
 
 		dateRequested = Date.parseUTCDate(movie.dateRequested);
-        if((new Date) - dateRequested >= 180 * 24 * 60 * 60 * 1000 || movie.status === 3){
+        if((new Date) - dateRequested >= this._regenerateMovieThreshold * 24 * 60 * 60 * 1000 || movie.status === 3){
 			this._rebuildItem(movie);
 			return false;
         }
@@ -1202,6 +1203,7 @@ var MovieManagerUI = MediaManagerUI.extend(
     _refresh: function () {
         var status, statusMsg, dateRequested;
 
+        let regenThreshold = this._regenerateMovieThreshold;
         // Update the status information for each row in the history
         $.each(this._manager.toArray(), function (i, item) {
             status = $("#movie-" + item.id).find(".status");
@@ -1209,7 +1211,7 @@ var MovieManagerUI = MediaManagerUI.extend(
             // For completed entries, display elapsed time
             if (item.status === 2) {
                 dateRequested = Date.parseUTCDate(item.dateRequested);
-                if((new Date) - dateRequested >= 180 * 24 * 60 * 60 * 1000){
+                if((new Date) - dateRequested >= regenThreshold * 24 * 60 * 60 * 1000){
 					statusMsg = '<span class="rebuild-item" data-id="'+item.id+'" title="Regenerate movie"> regenerate <span class="fa fa-refresh"></span></span>';
                 }else{
 	                statusMsg = dateRequested.getElapsedTime();

--- a/resources/js/Utility/Config.js
+++ b/resources/js/Utility/Config.js
@@ -14,28 +14,29 @@ var Config = Class.extend(
      * Default parameters
      */
      params: {
-        'back_end'             	: "https://api.helioviewer.org/",
-        'web_root_url'         	: "https://helioviewer.org",
-	    'build_num'             : 700,
-        'default_image_scale'   : 4.8408817,
-        'min_image_scale'       : 0.60511022,
-        'max_image_scale'       : 154.90822,
-        'max_tile_layers'       : 5,
-        'prefetch_size'        	: 0,
-        'news_url'             	: "https://helioviewer-project.github.io/",
-        'user_video_feed'       : "https://api.helioviewer.org/",
-        'contact_email'        	: "contact@helioviewer.org"
+        'back_end'                  : "https://api.helioviewer.org/",
+        'web_root_url'              : "https://helioviewer.org",
+        'build_num'                 : 700,
+        'default_image_scale'       : 4.8408817,
+        'min_image_scale'           : 0.60511022,
+        'max_image_scale'           : 154.90822,
+        'max_tile_layers'           : 5,
+        'prefetch_size'             : 0,
+        'news_url'                  : "https://helioviewer-project.github.io/",
+        'user_video_feed'           : "https://api.helioviewer.org/",
+        'contact_email'             : "contact@helioviewer.org",
+        'regenerate_movie_threshold': 90
      },
-    
+
     /**
      * @description Creates a new Config.
      * @constructs
      */
     init: function (params) {
         var self = this;
-        
+
         $.each(params, function (k,v) {
-	        self.params[k] = v;
+            self.params[k] = v;
         });
 
         this.bools  = [];
@@ -79,18 +80,19 @@ var Config = Class.extend(
      */
     toArray: function () {
         return {
-            'version'             : this.params["build_num"],
-            'defaultImageScale'   : this.params["default_image_scale"],
-            'minImageScale'       : this.params["min_image_scale"],
-            'maxImageScale'       : this.params["max_image_scale"],
-            'maxTileLayers'       : this.params["max_tile_layers"],
-            'prefetchSize'        : this.params["prefetch_size"],
-            'backEnd'             : this.params["back_end"],
-            'newsURL'             : this.params["news_url"],
-            'rootURL'             : this.params["web_root_url"],
-            'videoFeed'           : this.params["user_video_feed"],
-            'contactEmail'        : this.params["contact_email"],
-            'apiURL'              : this.params["back_end"]
+            'version'                 : this.params["build_num"],
+            'defaultImageScale'       : this.params["default_image_scale"],
+            'minImageScale'           : this.params["min_image_scale"],
+            'maxImageScale'           : this.params["max_image_scale"],
+            'maxTileLayers'           : this.params["max_tile_layers"],
+            'prefetchSize'            : this.params["prefetch_size"],
+            'backEnd'                 : this.params["back_end"],
+            'newsURL'                 : this.params["news_url"],
+            'rootURL'                 : this.params["web_root_url"],
+            'videoFeed'               : this.params["user_video_feed"],
+            'contactEmail'            : this.params["contact_email"],
+            'apiURL'                  : this.params["back_end"],
+            'regenerateMovieThreshold': this.params["regenerate_movie_threshold"]
         };
     }
 });


### PR DESCRIPTION
The API is currently set up to delete movies older than 90 days. This is managed by a cron job and not defined in the source code. The front-end should align, so I've added this as an option to the config

This fixes #306 