### PR TITLE
Use default setting if value is null

### DIFF
--- a/resources/js/Utility/UserSettings.js
+++ b/resources/js/Utility/UserSettings.js
@@ -48,7 +48,11 @@ var UserSettings = Class.extend(
     get: function (key) {
         // Nesting depth is limited to three levels
         try {
-            return this._get(key);
+            let tentative_value = this._get(key);
+            if (tentative_value == null) {
+                throw "Use default key";
+            }
+            return tentative_value;
         } catch (ex) {
             // If an error is encountered, then settings are likely outdated;
             // use the default value


### PR DESCRIPTION
Fixes #407 

Issue was that I changed settings object to support including CCMC Flare predictions.
The previous settings object didn't contain the new values in the local storage, and I failed to check if the setting was null.
🤦🏽‍♂️ 