### PR TITLE
Increase zoom level and fix issues with zooming in on sub-disk images like IRIS and XRT

### DIFF
--- a/index.php
+++ b/index.php
@@ -1983,7 +1983,7 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 		$( document ).ready(function(){
 			settingsJSON = {};
 			serverSettings = new Config(settingsJSON).toArray();
-			zoomLevels = [0.60511022,1.21022044,2.42044088,4.84088176,9.68176352,19.36352704,38.72705408,77.45410816,154.90821632];
+			zoomLevels = [0.30255511, 0.60511022,1.21022044,2.42044088,4.84088176,9.68176352,19.36352704,38.72705408,77.45410816,154.90821632];
 
 			urlSettings = getUrlParameters();
 

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -60,13 +60,15 @@ var TileLayer = Layer.extend(
         // Update the start/end values based on the known offset.
         let offset = this._getOffset();
         let xTileOffset = Math.round(offset.x / this.tileSize);
-        range.xStart += xTileOffset;
-        range.xEnd += xTileOffset;
-
         let yTileOffset = Math.round(offset.y / this.tileSize);
-        range.yStart += yTileOffset;
-        range.yEnd += yTileOffset;
-        this.tileLoader.updateTileVisibilityRange(range, this.loaded);
+        // Don't modify range directly since the object is shared across layers.
+        // Instead, create a new object with the updated fields
+        this.tileLoader.updateTileVisibilityRange({
+            xStart: range.xStart + xTileOffset,
+            xEnd: range.xEnd + xTileOffset,
+            yStart: range.yStart + yTileOffset,
+            yEnd: range.yEnd + yTileOffset
+        }, this.loaded);
     },
 
     /**

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -63,9 +63,11 @@ var TileLayer = Layer.extend(
      *
      */
     updateImageScale: function (scale, tileVisibilityRange) {
+        this.viewportScale = scale;
+
         // The general visibility range doesn't account for any x/y offsets.
         // Update the start/end values based on the known offset.
-        let offset = this._getOffset();
+        let offset = this._getOffset(scale);
         let xTileOffset = Math.round(offset.x / this.tileSize);
         let yTileOffset = Math.round(offset.y / this.tileSize);
         // Don't modify range directly since the object is shared across layers.
@@ -73,12 +75,12 @@ var TileLayer = Layer.extend(
         // With pinch scaling, these can end up being non-whole numbers from rounding
         // errors. Instead of -1, we get -0.9999999 which results in the whole
         // range being wrong.
+        this.viewportScale = scale;
         // Round everything to whole numbers to make sure this always works.
         tileVisibilityRange.xStart = Math.round(tileVisibilityRange.xStart) + xTileOffset;
         tileVisibilityRange.yStart = Math.round(tileVisibilityRange.yStart) + yTileOffset;
         tileVisibilityRange.xEnd = Math.round(tileVisibilityRange.xEnd) + xTileOffset;
         tileVisibilityRange.yEnd = Math.round(tileVisibilityRange.yEnd) + yTileOffset;
-        this.viewportScale = scale;
 
         this._updateDimensions();
 
@@ -117,11 +119,11 @@ var TileLayer = Layer.extend(
         }
     },
 
-    _getOffset: function () {
+    _getOffset: function (viewportScale) {
         var scaleFactor, offsetX, offsetY;
 
         // Ratio of original JP2 image scale to the viewport/desired image scale
-        scaleFactor = this.image.scale / this.viewportScale;
+        scaleFactor = this.image.scale / viewportScale;
 
         this.width  = this.image.width  * scaleFactor;
         this.height = this.image.height * scaleFactor;
@@ -148,7 +150,7 @@ var TileLayer = Layer.extend(
      *   at the bottom-left corner of the image, not the top-left corner.
      */
     _updateDimensions: function () {
-        let offset = this._getOffset();
+        let offset = this._getOffset(this.viewportScale);
 
         // Update layer dimensions
         this.dimensions = {

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -56,6 +56,13 @@ var TileLayer = Layer.extend(
     },
 
     updateTileVisibilityRange: function (range) {
+        this.tileLoader.updateTileVisibilityRange(range, this.loaded);
+    },
+
+    /**
+     *
+     */
+    updateImageScale: function (scale, tileVisibilityRange) {
         // The general visibility range doesn't account for any x/y offsets.
         // Update the start/end values based on the known offset.
         let offset = this._getOffset();
@@ -63,27 +70,16 @@ var TileLayer = Layer.extend(
         let yTileOffset = Math.round(offset.y / this.tileSize);
         // Don't modify range directly since the object is shared across layers.
         // Instead, create a new object with the updated fields
-        this.tileLoader.updateTileVisibilityRange({
-            xStart: range.xStart + xTileOffset,
-            xEnd: range.xEnd + xTileOffset,
-            yStart: range.yStart + yTileOffset,
-            yEnd: range.yEnd + yTileOffset
-        }, this.loaded);
-    },
-
-    /**
-     *
-     */
-    updateImageScale: function (scale, tileVisibilityRange) {
         // With pinch scaling, these can end up being non-whole numbers from rounding
         // errors. Instead of -1, we get -0.9999999 which results in the whole
         // range being wrong.
         // Round everything to whole numbers to make sure this always works.
-        tileVisibilityRange.xStart = Math.round(tileVisibilityRange.xStart);
-        tileVisibilityRange.yStart = Math.round(tileVisibilityRange.yStart);
-        tileVisibilityRange.xEnd = Math.round(tileVisibilityRange.xEnd);
-        tileVisibilityRange.yEnd = Math.round(tileVisibilityRange.yEnd);
+        tileVisibilityRange.xStart = Math.round(tileVisibilityRange.xStart) + xTileOffset;
+        tileVisibilityRange.yStart = Math.round(tileVisibilityRange.yStart) + yTileOffset;
+        tileVisibilityRange.xEnd = Math.round(tileVisibilityRange.xEnd) + xTileOffset;
+        tileVisibilityRange.yEnd = Math.round(tileVisibilityRange.yEnd) + yTileOffset;
         this.viewportScale = scale;
+
         this._updateDimensions();
 
         this.tileLoader.setTileVisibilityRange(tileVisibilityRange);

--- a/resources/js/Utility/Config.js
+++ b/resources/js/Utility/Config.js
@@ -18,7 +18,7 @@ var Config = Class.extend(
         'web_root_url'              : "https://helioviewer.org",
         'build_num'                 : 700,
         'default_image_scale'       : 4.8408817,
-        'min_image_scale'           : 0.60511022,
+        'min_image_scale'           : 0.30255511,
         'max_image_scale'           : 154.90822,
         'max_tile_layers'           : 5,
         'prefetch_size'             : 0,


### PR DESCRIPTION
When zooming in on a partial image like IRIS or XRT, sometimes the subimage tiles are not computed correctly which ends up only showing half of the image.

This was caused by the general tileVisibility range assuming the image is a full-disk image. The solution here is to offset the tile indices based on the image's offset in the viewport.

As a contrived example, say you are looking at tile section (3,4). This is out of range of normal operation, but just being used as an example. If a sub image exists in this area, its tile values will still be (-1, -1), (-1, 0), (0, -1), (0, 0). resulting in the image not displaying at all. With this solution, it computes the offset with the _getOffset function I added. Then divides the offset by the tile size to see how many tiles the visibility range should be shifted and updates the visibilty range appropriately.

So while the main image source is showing tiles (3, 4), the offset will be applied so the sub image is showing tiles in the (0, 0) range.