### PR TITLE
Fix various issues with sub-disk images and zooming in and out

### DIFF
--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -380,5 +380,17 @@ var TileLayer = Layer.extend(
         img.galleryimg    = 'no';
 
         return img;
+    },
+
+    getArea: function () {
+        return this.width * this.height;
+    },
+
+    /**
+     * Returns the current positional offset
+     * @note Internal usage in this class should use _getOffset instead.
+     */
+    getCurrentOffset: function () {
+        return this._getOffset(this.viewportScale);
     }
 });

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -76,14 +76,16 @@ var TileLayer = Layer.extend(
         // errors. Instead of -1, we get -0.9999999 which results in the whole
         // range being wrong.
         // Round everything to whole numbers to make sure this always works.
-        tileVisibilityRange.xStart = Math.round(tileVisibilityRange.xStart) + xTileOffset;
-        tileVisibilityRange.yStart = Math.round(tileVisibilityRange.yStart) + yTileOffset;
-        tileVisibilityRange.xEnd = Math.round(tileVisibilityRange.xEnd) + xTileOffset;
-        tileVisibilityRange.yEnd = Math.round(tileVisibilityRange.yEnd) + yTileOffset;
+        let offsetVisibilityRange = {
+            xStart: Math.round(tileVisibilityRange.xStart) + xTileOffset,
+            xEnd: Math.round(tileVisibilityRange.xEnd) + xTileOffset,
+            yStart: Math.round(tileVisibilityRange.yStart) + yTileOffset,
+            yEnd: Math.round(tileVisibilityRange.yEnd) + yTileOffset
+        }
 
         this._updateDimensions();
 
-        this.tileLoader.setTileVisibilityRange(tileVisibilityRange);
+        this.tileLoader.setTileVisibilityRange(offsetVisibilityRange);
 
         if (this.visible) {
             this.tileLoader.reloadTiles(true);

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -68,8 +68,8 @@ var TileLayer = Layer.extend(
         // The general visibility range doesn't account for any x/y offsets.
         // Update the start/end values based on the known offset.
         let offset = this._getOffset(scale);
-        let xTileOffset = Math.floor(offset.x / this.tileSize);
-        let yTileOffset = Math.floor(offset.y / this.tileSize);
+        let xTileOffset = this._computeTileOffset(offset.x, this.tileSize);
+        let yTileOffset = this._computeTileOffset(offset.y, this.tileSize);
         // Don't modify range directly since the object is shared across layers.
         // Instead, create a new object with the updated fields
         // With pinch scaling, these can end up being non-whole numbers from rounding
@@ -89,6 +89,24 @@ var TileLayer = Layer.extend(
 
         if (this.visible) {
             this.tileLoader.reloadTiles(true);
+        }
+    },
+
+    /**
+     * Computes the tile index offset that is required based on the given position offset
+     * @param {number} posOffset
+     * @param {number} tileSize
+     */
+    _computeTileOffset: function(posOffset, tileSize) {
+        // The tile offset is determined by how many tiles over the tilesize the position is shifted.
+        // For example, the top left tile is usually (-1, -1). The viewport may be shifted to the right so that only tile (0, -1) should be visible.
+        // However, if the positional offset for this image is also shifted to the right, then it may be appropriate to still show tile (-1, -1).
+        // This calculation determines this tile value offset based on the images position in the viewport.
+        let tileOffset = Math.floor(Math.abs(posOffset / tileSize));
+        if (posOffset >= 0) {
+            return tileOffset;
+        } else {
+            return -tileOffset;
         }
     },
 

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -68,8 +68,8 @@ var TileLayer = Layer.extend(
         // The general visibility range doesn't account for any x/y offsets.
         // Update the start/end values based on the known offset.
         let offset = this._getOffset(scale);
-        let xTileOffset = Math.round(offset.x / this.tileSize);
-        let yTileOffset = Math.round(offset.y / this.tileSize);
+        let xTileOffset = Math.floor(offset.x / this.tileSize);
+        let yTileOffset = Math.floor(offset.y / this.tileSize);
         // Don't modify range directly since the object is shared across layers.
         // Instead, create a new object with the updated fields
         // With pinch scaling, these can end up being non-whole numbers from rounding

--- a/resources/js/Tiling/Manager/TileLayerManager.js
+++ b/resources/js/Tiling/Manager/TileLayerManager.js
@@ -365,5 +365,21 @@ var TileLayerManager = LayerManager.extend(
         });
 
         return this._stringify(layers);
+    },
+
+    /**
+     * Returns the largest layer (by dimensions) that is currently displayed.
+     */
+    getBiggestLayer: function () {
+        let maxArea = 0;
+        let biggestLayer = this._layers[0];
+        this._layers.forEach((layer) => {
+            let layerArea = layer.getArea();
+            if (layerArea > maxArea) {
+                maxArea = layerArea;
+                biggestLayer = layer;
+            }
+        })
+        return biggestLayer;
     }
 });

--- a/resources/js/UI/ImageScale.js
+++ b/resources/js/UI/ImageScale.js
@@ -53,16 +53,18 @@ var ImageScale = Class.extend(
             'position'    : 'absolute',
             'z-index'     : '999',
             'width'       : '95px',
-            'height'      : '80px',
+            'min-height'      : '80px',
             'background-color':'rgba(17,17,17,0.5)',
             'border'      : '1px solid #888',
             'box-shadow'  : '0px 0px 5px black',
-            'cursor'      : 'move'
+            'cursor'      : 'move',
+            'display'     : 'flex',
+            'flex-direction': 'column'
         });
         this.container.attr('title','Click and drag to re-position scale indicator.');
 
         $('<div style="position:relative; z-index: 10;"><div id="earthLabel" style="color: white; background-color: #333; text-align: center; font-size: 10px; padding: 2px 0 2px 2px;">Earth Scale</div></div>').appendTo("#earth-container");
-        $('<div style="position:relative; text-align: center; width:95px; height:65px;"><div id="barScaleBlock"><p id="barScaleLabel" style="padding:0px 10px;text-align:center;font-size:8px;margin:13px 0px 5px;">'+this.scaleBarSizeInKM+' km</p><div id="js-bar-scale" style="display:block;clear:both;margin:0px auto;height:4px;border:2px solid #fcfcfc;border-top:none;width:50px"></div></div><div style="width: 100%; height: 100%; line-height: 50px; display: flex; justify-content: center; align-items: center;"><img id="earthScale" src="resources/images/earth.png" style="width: '+this.earthDiameterInPixels+'px; height: '+this.earthDiameterInPixels+'px; vertical-align: middle;" alt="Earth scale image" /></div></div>').appendTo("#earth-container");
+        $('<div  style="display: flex;align-content: center; justify-content: center; flex-grow: 1; position:relative; text-align: center;"><div id="barScaleBlock"><p id="barScaleLabel" style="padding:0px 10px;text-align:center;font-size:8px;margin:13px 0px 5px;">'+this.scaleBarSizeInKM+' km</p><div id="js-bar-scale" style="display:block;clear:both;margin:0px auto;height:4px;border:2px solid #fcfcfc;border-top:none;width:50px"></div></div><div id="js-earth-scale" style="line-height: 50px; display: flex; justify-content: center; align-items: center;"><img id="earthScale" src="resources/images/earth.png" style="width: '+this.earthDiameterInPixels+'px; height: '+this.earthDiameterInPixels+'px; vertical-align: middle;" alt="Earth scale image" /></div></div>').appendTo("#earth-container");
 
         this.scale_button    = $(document).find('#earth-button');
         this.scale_image     = this.container.find('#earthScale');

--- a/resources/js/Viewport/HelioviewerViewport.js
+++ b/resources/js/Viewport/HelioviewerViewport.js
@@ -210,12 +210,12 @@ var HelioviewerViewport = Class.extend(
                    .bind("layer-max-dimensions-changed",
                          $.proxy(this.updateMaxLayerDimensions, this))
                    .bind("center-viewport",
-                         $.proxy(this.centerViewport, this));
+                         $.proxy(this.centerViewportOnBiggestLayer, this));
 
         $(this.domNode).bind("mousedown", $.proxy(this.onMouseMove, this));
         this.domNode.dblclick($.proxy(this.doubleClick, this));
 
-        $('#center-button').click($.proxy(this.centerViewport, this));
+        $('#center-button').click($.proxy(this.centerViewportOnBiggestLayer, this));
         $(window).resize($.proxy(this.resize, this));
     },
 
@@ -339,6 +339,25 @@ var HelioviewerViewport = Class.extend(
         this.updateViewport();
         Helioviewer.userSettings.set("state.centerX", 0);
         Helioviewer.userSettings.set("state.centerY", 0);
+    },
+
+    /**
+     * Moves the image back to the center of the viewport.
+     */
+    centerViewportOnBiggestLayer: function () {
+        let biggestLayer = this._getBiggestLayer();
+        let offset = biggestLayer.getCurrentOffset();
+        this.movementHelper.centerViewportWithOffset(offset.x, offset.y);
+        this.updateViewport();
+        Helioviewer.userSettings.set("state.centerX", offset.x);
+        Helioviewer.userSettings.set("state.centerY", offset.y);
+    },
+
+    /**
+     * Returns the largest layer (by dimensions) that is currently displayed.
+     */
+    _getBiggestLayer: function () {
+        return this._tileLayerManager.getBiggestLayer();
     },
 
     /**

--- a/resources/js/Viewport/Helper/HelioviewerZoomer.js
+++ b/resources/js/Viewport/Helper/HelioviewerZoomer.js
@@ -17,7 +17,6 @@
         this._scale = 1;
         this._anchor = {left: 0, top: 0};
         this._last_size = 0;
-        this._zoomSlider = $('#zoomControlSlider');
     }
 
     _initializePinchListeners() {
@@ -80,12 +79,23 @@
     }
 
     /**
+     * Updates the size of the bounding box that contains the earth image
+     */
+    _updateScaleBoxSize(boxId, imgId) {
+        let el = document.getElementById(boxId);
+        let img = document.getElementById(imgId);
+        let rect = img.getBoundingClientRect();
+        el.style.minHeight = rect.height + 'px';
+    }
+
+    /**
      * Updates the size of the earth scale/bar scale
      * These elements are added dynamically, so can't be cached.
      */
     _updateReferenceScale(scale) {
         this._updateScaleForElementWithId('js-bar-scale', scale);
         this._updateScaleForElementWithId('earthScale', scale);
+        this._updateScaleBoxSize('js-earth-scale', 'earthScale');
     }
 
     setScale(scale) {
@@ -127,7 +137,7 @@
         let y = center.top - parseInt(this._sandbox.style.top) - container_pos.top;
         x = x / this._scale;
         y = y / this._scale;
-        /** for visualizing clicks 
+        /** for visualizing clicks
          let sandbox_pos = $('#sandbox').position();
          let div = document.createElement('div');
          div.style.width = "25px";

--- a/resources/js/Viewport/Helper/SandboxHelper.js
+++ b/resources/js/Viewport/Helper/SandboxHelper.js
@@ -20,26 +20,19 @@ var SandboxHelper = Class.extend(
      * Find the center of the sandbox and put the movingContainer there
      */
     center: function () {
-        var top, left;
+        let center = this.getCenter();
+        this.moveContainerTo(center.x, center.y);
+    },
 
-        //Get ViewPort size offset
-        var heightOffset = $(window).height();
-        var widthOffset = $(window).width();
-
-        left = 0.5 * this.domNode.width();
-        top  = 0.5 * this.domNode.height();
-
-        this.moveContainerTo(left, top);
+    centerWithOffset: function (x, y) {
+        let center = this.getCenter();
+        this.moveContainerTo(center.x + x, center.y + y);
     },
 
     /**
      * Find the center of the sandbox
      */
     getCenter: function () {
-        //Get ViewPort size offset
-        var heightOffset = $(window).height();
-        var widthOffset = $(window).width();
-
         return {
             x: 0.5 * this.domNode.width(),
             y: 0.5 * this.domNode.height()

--- a/resources/js/Viewport/Helper/ViewportMovementHelper.js
+++ b/resources/js/Viewport/Helper/ViewportMovementHelper.js
@@ -54,6 +54,15 @@ var ViewportMovementHelper = Class.extend(
     },
 
     /**
+     * Centers the viewport on the given offset
+     * @param {number} x
+     * @param {number} y
+     */
+    centerViewportWithOffset: function (x, y) {
+        this.sandboxHelper.centerWithOffset(x, y);
+    },
+
+    /**
      * @description Fired when a mouse is pressed
      * @param {Event} event an Event object
      */


### PR DESCRIPTION
Fixes problems where sub-disk images are only partially loaded when zooming in and out while the viewport focus is away from the center of the sun.

Makes the "center-viewport" UI button work when only a sub-disk image is displayed. (Old behavior is to center the viewport on the center of the sun, which may not be rendered if only a sub-disk image is showing such as from IRIS or XRT).

Makes the earth-scale box a little bigger, and stretchy on mobile so it always contains the earth.