### PR TITLE
Make screenshots and movies align with mobile viewport

### DIFF
--- a/resources/js/HelioviewerWebClient.js
+++ b/resources/js/HelioviewerWebClient.js
@@ -1782,6 +1782,10 @@ var HelioviewerWebClient = HelioviewerClient.extend(
         return this.viewport.getImageScale();
     },
 
+    getZoomedImageScale: function () {
+        return this.viewport.getZoomedImageScale();
+    },
+
     /**
      * Returns the top-left and bottom-right coordinates for the viewport region of interest
      *
@@ -1789,6 +1793,27 @@ var HelioviewerWebClient = HelioviewerClient.extend(
      */
     getViewportRegionOfInterest: function () {
         return this.viewport.getRegionOfInterest();
+    },
+
+    /**
+     * Returns the top-left and bottom-right coordinates for the viewport region of interest accounting for zoom
+     *
+     * @return {Object} Current ROI
+     */
+    getZoomedRegionOfInterest: function () {
+        let zoom = (Helioviewer.userSettings.get('mobileZoomScale') || 1);
+        let roi = this.viewport.getRegionOfInterest();
+
+        let roiWidth = roi.right - roi.left;
+        let roiXOffset = ((roiWidth * zoom) - roiWidth) / 2;
+        let roiHeight = roi.bottom - roi.top;
+        let roiYOffset = ((roiHeight * zoom) - roiHeight) / 2;
+        return {
+            left: roi.left * zoom + roiXOffset,
+            right: roi.left * zoom + roiXOffset + roiWidth,
+            top: roi.top * zoom + roiYOffset,
+            bottom: roi.top * zoom + roiYOffset + roiHeight
+        };
     },
 
     /**

--- a/resources/js/Media/MovieManagerUI.js
+++ b/resources/js/Media/MovieManagerUI.js
@@ -77,24 +77,6 @@ var MovieManagerUI = MediaManagerUI.extend(
 			this._movieEventsLabels = false;
 		}
 
-		/*if(typeof formParams['startTime'] != 'undefined'){
-			var roi = helioviewer.getViewportRegionOfInterest();
-			var layers = helioviewer.getVisibleLayers(roi);
-			var events = helioviewer.getEvents();
-
-			// Make sure selection region and number of layers are acceptible
-			if (!this._validateRequest(roi, layers)) {
-				return;
-			}
-
-			// Store chosen ROI and layers
-			this._movieScale  = helioviewer.getImageScale();
-			this._movieROI	= this._toArcsecCoords(roi, this._movieScale);
-			this._movieLayers = layers;
-			this._movieEvents = events;
-			this._movieEventsLabels = helioviewer.getEventsLabels();
-		}*/
-
 		var switchSources = false;
 		if(outputType == 'minimal'){
 			switchSources = true;
@@ -210,7 +192,7 @@ var MovieManagerUI = MediaManagerUI.extend(
 	 */
 	_showMovieSettings: function (roi) {
 		if (typeof roi === "undefined") {
-			roi = helioviewer.getViewportRegionOfInterest();
+			roi = helioviewer.getZoomedRegionOfInterest();
 		}
 
 		var layers = helioviewer.getVisibleLayers(roi);
@@ -222,7 +204,7 @@ var MovieManagerUI = MediaManagerUI.extend(
 		}
 
 		// Store chosen ROI and layers
-		this._movieScale  = helioviewer.getImageScale();
+		this._movieScale  = helioviewer.getZoomedImageScale();
 		this._movieROI	= this._toArcsecCoords(roi, this._movieScale);
 		this._movieLayers = layers;
 		this._movieEvents = events;

--- a/resources/js/Media/ScreenshotManagerUI.js
+++ b/resources/js/Media/ScreenshotManagerUI.js
@@ -163,14 +163,14 @@ var ScreenshotManagerUI = MediaManagerUI.extend(
      * viewport roi
      */
     _takeScreenshot: function (roi) {
-        var params, dataType, imageScale, layers, events, eventLabels, celestialBodiesLabels,
-        celestialBodiesTrajectories, scale, scaleType, scaleX, scaleY, screenshot, self = this;
+        var params, imageScale, layers, events, eventLabels, celestialBodiesLabels,
+        celestialBodiesTrajectories, screenshot, self = this;
 
         if (typeof roi === "undefined") {
-            roi = helioviewer.getViewportRegionOfInterest();
+            roi = helioviewer.getZoomedRegionOfInterest();
         }
 
-        imageScale  = helioviewer.getImageScale();
+        imageScale  = helioviewer.getZoomedImageScale();
         layers      = helioviewer.getVisibleLayers(roi);
         events      = helioviewer.getEvents();
         celestialBodiesLabels = helioviewer.getCelestialBodiesLabels();
@@ -185,12 +185,12 @@ var ScreenshotManagerUI = MediaManagerUI.extend(
         if (!this._validateRequest(roi, layers)) {
             return;
         }
-		
+
 		var switchSources = false;
 		if(outputType == 'minimal'){
 			switchSources = true;
 		}
-		
+
         params = $.extend({
             action        : "takeScreenshot",
             imageScale    : imageScale,

--- a/resources/js/Tiling/Manager/TileLayerManager.js
+++ b/resources/js/Tiling/Manager/TileLayerManager.js
@@ -338,16 +338,18 @@ var TileLayerManager = LayerManager.extend(
         // Solar radius at 1au (TODO: compute for layer)
         rsunAS = 959.705;
 
+        let zoom = (Helioviewer.userSettings.get('mobileZoomScale') || 1)
         $.each(this._layers, function (i, layer) {
             // Check visibility
             if (!layer.visible || layer.opacity <= 5) {
                 return;
             }
+
             // Check overlap
-            if ((roi.right <= layer.dimensions.left + threshold) ||
-                (roi.bottom <= layer.dimensions.top + threshold) ||
-                (roi.left >= layer.dimensions.right - threshold) ||
-                (roi.top >= layer.dimensions.bottom - threshold)) {
+            if ((roi.right <= (layer.dimensions.left * zoom) + threshold) ||
+                (roi.bottom <= (layer.dimensions.top * zoom) + threshold) ||
+                (roi.left >= (layer.dimensions.right * zoom) - threshold) ||
+                (roi.top >= (layer.dimensions.bottom * zoom) - threshold)) {
                 return;
             }
 

--- a/resources/js/Viewport/HelioviewerViewport.js
+++ b/resources/js/Viewport/HelioviewerViewport.js
@@ -104,6 +104,14 @@ var HelioviewerViewport = Class.extend(
     },
 
     /**
+     * @description Returns the current image scale (in arc-seconds/px) accounting for mobile zoom.
+     */
+    getZoomedImageScale: function () {
+        let zoom = (Helioviewer.userSettings.get('mobileZoomScale') || 1);
+        return this.getImageScale() / zoom;
+    },
+
+    /**
      * Gets the window height and resizes the viewport to fit within it
      */
     resize: function () {

--- a/resources/js/Viewport/Helper/HelioviewerZoomer.js
+++ b/resources/js/Viewport/Helper/HelioviewerZoomer.js
@@ -17,6 +17,8 @@
         this._scale = 1;
         this._anchor = {left: 0, top: 0};
         this._last_size = 0;
+        Helioviewer.userSettings.set('mobileZoomScale', 1);
+        $(document).bind("update-viewport", $.proxy(this.onUpdateViewport, this))
     }
 
     _initializePinchListeners() {
@@ -106,6 +108,7 @@
             } else if (scale <= 0.5) {
                 this._zoomHelioviewer(scale, false);
             } else {
+                Helioviewer.userSettings.set('mobileZoomScale', scale);
                 this._scale = scale;
                 this._mc.style.transform = "scale(" + this._scale + ")";
                 this._updateReferenceScale(scale)
@@ -137,19 +140,6 @@
         let y = center.top - parseInt(this._sandbox.style.top) - container_pos.top;
         x = x / this._scale;
         y = y / this._scale;
-        /** for visualizing clicks
-         let sandbox_pos = $('#sandbox').position();
-         let div = document.createElement('div');
-         div.style.width = "25px";
-         div.style.height = "25px";
-         div.style.position = "absolute";
-         div.style.left = (x)  + "px";
-         div.style.top = (y) + "px";
-         div.style.background = "purple";
-         div.style.transform = "translateX(-50%) translateY(-50%)";
-         $('#moving-container')[0].appendChild(div);
-         /**/
-        // return {left: 0, top: 0};
         this.setAnchor({left: x, top: y});
     }
 
@@ -171,6 +161,15 @@
     }
 
     pinchEnd() {
+    }
+
+    onUpdateViewport() {
+        // Set anchor to center screen
+        let center = {
+            left: window.innerWidth / 2,
+            top: window.innerHeight / 2
+        }
+        this.setAnchorForCenter(center);
     }
 
     /**

--- a/resources/js/Viewport/Helper/MouseCoordinates.js
+++ b/resources/js/Viewport/Helper/MouseCoordinates.js
@@ -146,7 +146,8 @@ var MouseCoordinates = Class.extend(
         };
 
         //scale
-        scale = this.imageScale;
+        let zoom = (Helioviewer.userSettings.get('mobileZoomScale') || 1);
+        scale = this.imageScale / zoom;
         x = Math.round((scale * MX.x));
         y = - Math.round((scale * MX.y));
 

--- a/resources/js/Viewport/Helper/ViewportMovementHelper.js
+++ b/resources/js/Viewport/Helper/ViewportMovementHelper.js
@@ -190,16 +190,8 @@ var ViewportMovementHelper = Class.extend(
         left = -(sb.left + mc.left);
         top  = -(sb.top + mc.top);
 
-        // If dimension is an odd value, add one to ensure that (0, 0) is in center
         vpWidth  = this.domNode.width();
         vpHeight = this.domNode.height();
-
-        //if (vpWidth % 2 === 1) {
-        //    vpWidth += 1;
-        //}
-        //if (vpHeight % 2 === 1) {
-        //    vpHeight += 1;
-        //}
 
         return {
             left:  left,


### PR DESCRIPTION
Since we implemented the mobile view, screenshots and movies have not correctly followed the mobile viewport since they never accounted for the "in-between" zoom states.

This change updates several calculations to account for the extra scaling implemented in mobile.