### PR TITLE
Remove link shorten option for movies

### DIFF
--- a/index.php
+++ b/index.php
@@ -1411,11 +1411,7 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 			<div id="helioviewer-url-box">
 				<span id="helioviewer-url-box-msg"></span>
 				<form style="margin-top: 5px;">
-					<input aria-label="Viewport URL" type="text" class="helioviewer-url-input-box helioviewer-url-input-box-video" style="width:98%;" value="https://helioviewer.org" />
-					<label for="helioviewer-url-shorten">Shorten link: </label>
-					<input id="helioviewer-url-shorten" type="checkbox" class="helioviewer-url-shorten" />
-					<input type="hidden" class="helioviewer-short-url" value="" />
-					<input type="hidden" class="helioviewer-long-url" value="" />
+					<input aria-label="Movie URL" type="text" class="helioviewer-url-input-box helioviewer-url-input-box-video" style="width:98%;" value="https://helioviewer.org" readonly/>
 				</form>
 			</div>
 		</div>


### PR DESCRIPTION
Closes #497 

I'm making the executive decision that the movie urls don't need a link shortener since the shortened link would actually be longer than the movie url with the existing link shortener.
