### PR TITLE
Issue #498 - Update MovieManagerUI.js

### DIFF
--- a/resources/js/Media/MovieManagerUI.js
+++ b/resources/js/Media/MovieManagerUI.js
@@ -422,19 +422,11 @@ var MovieManagerUI = MediaManagerUI.extend(
 		//Movie Generation time pickers
 		$('#movie-start-date').flatpickr({
 			allowInput: true,
-			dateFormat: 'Y/m/d',
-			onOpen: function (selected, str, instance) {
-				var observationDate = new Date(Helioviewer.userSettings.get("state.date"));
-				instance.set(observationDate.toUTCDateString());
-			}
+			dateFormat: 'Y/m/d'
 		});
 		$('#movie-end-date').flatpickr({
 			allowInput: true,
-			dateFormat: 'Y/m/d',
-			onOpen: function (selected, str, instance) {
-				var observationDate = new Date(Helioviewer.userSettings.get("state.date"));
-				instance.set('minDate', observationDate.toUTCDateString());
-			}
+			dateFormat: 'Y/m/d'
 		});
 		if ($('#movie-start-date').length > 0) {
 			$('#movie-start-date')[0]._flatpickr.setDate(new Date(Helioviewer.userSettings.get("state.date") - duration).toUTCDateString());

--- a/resources/js/Media/MovieManagerUI.js
+++ b/resources/js/Media/MovieManagerUI.js
@@ -425,7 +425,7 @@ var MovieManagerUI = MediaManagerUI.extend(
 			dateFormat: 'Y/m/d',
 			onOpen: function (selected, str, instance) {
 				var observationDate = new Date(Helioviewer.userSettings.get("state.date"));
-				instance.set('maxDate', observationDate.toUTCDateString());
+				instance.set(observationDate.toUTCDateString());
 			}
 		});
 		$('#movie-end-date').flatpickr({


### PR DESCRIPTION
Datepicker for advanced movie options blocks out dates that it shouldn't.

'maxDate' option defaults to null.
reference: https://flatpickr.js.org/options/

The option has been removed from flatpickr instance. This allows user to select future dates.