### PR TITLE
Fix 1px gap between image tiles when zooming

### DIFF
--- a/resources/css/helioviewer-base.css
+++ b/resources/css/helioviewer-base.css
@@ -68,6 +68,7 @@ a.light:hover {
     left: 0px;
     display: block;
     overflow: visible;
+    mix-blend-mode: plus-lighter;
     -moz-user-select: none;
 }
 

--- a/resources/js/Viewport/CelestialBodiesSatellites.js
+++ b/resources/js/Viewport/CelestialBodiesSatellites.js
@@ -525,7 +525,6 @@ var CelestialBodiesSatellites = Class.extend(
     },
 
     _replotCoordinates: function(){
-        console.log("Called replot coordinates");
         var self = this;
         var currentRequestTime = helioviewer.timeControls.getTimestamp();
 
@@ -568,7 +567,6 @@ var CelestialBodiesSatellites = Class.extend(
         }
 
         var observers = Object.keys(this.trajectories);
-        console.log(observers);
         for(var observer of observers){
             var bodies = Object.keys(this.trajectories[observer]);
             for(var body of bodies){

--- a/resources/js/Viewport/Helper/HelioviewerZoomer.js
+++ b/resources/js/Viewport/Helper/HelioviewerZoomer.js
@@ -131,7 +131,7 @@
 
     _updateScaleForElementWithId(id, scale) {
         let el = document.getElementById(id);
-        el.style.transform = "scale(" + scale + ")";
+        el.style.transform = "scale3d(" + scale + ", " + scale + ", 1)";
     }
 
     /**
@@ -164,7 +164,7 @@
             } else {
                 Helioviewer.userSettings.set('mobileZoomScale', scale);
                 this._scale = scale;
-                this._mc.style.transform = "scale(" + this._scale + ")";
+                this._updateScaleForElementWithId(this._mc.id, scale);
                 this._updateUIScale(scale);
                 this._updateReferenceScale(scale)
                 $(document).trigger('update-viewport');


### PR DESCRIPTION
The smooth zoom implementation leaves 1px gaps on chrome and safari.
This fixes the gaps in those browsers.

Tested on:
| browser | version |
|---------|---------|
| firefox | 115.7 |
| chrome | 120.0.6099.234 |
| safari | 17.2.1 |