### PR TITLE
Only run $.getJSON once

### DIFF
--- a/resources/js/CustomHandling/CustomHandling.js
+++ b/resources/js/CustomHandling/CustomHandling.js
@@ -1,148 +1,133 @@
 // START Encounter Count
 var menuenclblexists='no';
 
-function showEncounter() {
-	
-	
-	
-	var thishvurlstr = window.location.href;
-	
-	
-	if(thishvurlstr.search('beta.helioviewer')==-1) {
-		thishvapiurl= "https://api.helioviewer.org";
-	}
-	else {
+let _pspdata = new Promise((resolve, reject) => {
+	let thishvurlstr = window.location.href;
+	let thishvapiurl = "https://api.helioviewer.org";
+	if(thishvurlstr.search('beta.helioviewer')!=-1) {
 		thishvapiurl= "https://api.beta.helioviewer.org";
 	}
-	
+	$.getJSON(thishvapiurl+"/resources/JSON/celestial-objects/soho/psp/soho_psp_dictionary.json", resolve).fail(reject);
+});
+
+async function showEncounter() {
+	let pspdata = await _pspdata;
 	setTimeout(function() {
-
-	
-		$.getJSON(thishvapiurl+"/resources/JSON/celestial-objects/soho/psp/soho_psp_dictionary.json", function(pspdata){
-
-			var pspenctotal= Object.keys(pspdata).length;
+		var pspenctotal= Object.keys(pspdata).length;
+		
+		
+		var pspencnum=0;
+		
+		// loop through each encounter
+		$.each(pspdata, function(pspvalue, pspkey){
+			
+			pspencnum++;
 			
 			
-			var pspencnum=0;
+				//JSON.stringify(pspkey.start);
 			
-			// loop through each encounter
-			$.each(pspdata, function(pspvalue, pspkey){
+			// parse the JSON data: get the "start" value
+			var myPSPObj = JSON.parse(pspkey.start);
+			var pspstartenc = myPSPObj;
+			
+			
+			
+			// if the very first appropriate encounter div exists
+			if($('#soho-psp-container-hover-date-'+pspstartenc).length > 0 || $('#stereo_a-psp-trajectory-hover-date-'+pspstartenc).length > 0) {
+				$(".hover-date-container").removeClass("hvenclabels");
 				
 				
-				pspencnum++;
-				
-				
-				 //JSON.stringify(pspkey.start);
-				
-				// parse the JSON data: get the "start" value
-				var myPSPObj = JSON.parse(pspkey.start);
-				var pspstartenc = myPSPObj;
-				
-				
-				
-				// if the very first appropriate encounter div exists
-				if($('#soho-psp-container-hover-date-'+pspstartenc).length > 0 || $('#stereo_a-psp-trajectory-hover-date-'+pspstartenc).length > 0) {
-					$(".hover-date-container").removeClass("hvenclabels");
-					
-					
-					$('.hover-date-container').css('height','33px');
+				$('.hover-date-container').css('height','33px');
 
 
 
 
-					const hvencelems = document.getElementsByClassName('hvenclabels');
-						while(hvencelems.length > 0){
-						hvencelems[0].parentNode.removeChild(hvencelems[0]);
-						}
-					
-					/*if($("#hvencpagination").length > 0) {
-						const hvencpaginationelem = document.getElementById('hvencpagination');
-						hvencpaginationelem.remove();
-					}*/						
-
-					//hvencpaginationelem[0].parentNode.removeChild(hvencpaginationelem[0]);
-					
-					$(".hover-date-container").removeClass("hvenclabels");
-					
-					$('.hover-date-container').append('<span class="hvenclabels"></span>');
-					//$('#soho-psp-tree-trajectory').append('<span id="hvencpagination">'+pspencnum+'</span>');
-					
-					$('.hvenclabels').html('<br>Encounter '+pspencnum);
-					//document.getElementsByClassName("hover-date-container").innerHTML+= '<br>Encounter '+pspencnum;
-					
-					
-					if(menuenclblexists=='no') {
-						// prepend Encounter label
-						$('#soho-psp-tree-trajectory a, #stereo_a-psp-tree-trajectory a').after('<br><br><ins class="jstree-icon" style="background:none;">&nbsp;</ins><span class="menuenclabel" style="font-family: \'Courier New\',Courier,monospace;">Encounter: </span>');
-						menuenclblexists='yes';
+				const hvencelems = document.getElementsByClassName('hvenclabels');
+					while(hvencelems.length > 0){
+					hvencelems[0].parentNode.removeChild(hvencelems[0]);
 					}
-					
-					
-					// START generate encounter "pagination"
-						
-						if(pspencnum == 1) {
-							encdash1='';
-						}
-						else {
-							encdash1=' - ';
-						}
-						
-						if(pspencnum == pspenctotal) {
-							encdash2='';
-						}
-						else {
-							encdash2=' - ';
-						}
-						
-						// show current encounter in the pagination (SOHO)
-						$('#soho-psp-tree-trajectory .decoration').eq(1).html(encdash1+'<span style="border-radius:2px;background:white;color:black;font-weight:bold;">&nbsp;'+pspencnum+'&nbsp;</span>'+encdash2);
-						
-						// show current encounter in the pagination (Stereo A)
-						$('#stereo_a-psp-tree-trajectory .decoration').eq(1).html(encdash1+'<span style="border-radius:2px;background:white;color:black;font-weight:bold;">&nbsp;'+pspencnum+'&nbsp;</span>'+encdash2);
-						
-						// make the first and last .decoration <span> elements blank 
-						$('#soho-psp-tree-trajectory .decoration:first, #soho-psp-tree-trajectory .decoration:last, #stereo_a-psp-tree-trajectory .decoration:first, #stereo_a-psp-tree-trajectory .decoration:last').html('');
-						
-						
+				
+				/*if($("#hvencpagination").length > 0) {
+					const hvencpaginationelem = document.getElementById('hvencpagination');
+					hvencpaginationelem.remove();
+				}*/						
 
-						
-						// get previous encounter
-						if(pspencnum != 1) {
-							encpagprev=pspencnum-1;
-							$('#soho-psp-tree-trajectory .button:first, #stereo_a-psp-tree-trajectory .button:first').html('<br><ins class="jstree-icon" style="background:none;">&nbsp;</ins>&#9664; '+encpagprev);
-						}
-						else if(pspencnum == 1) {
-							$('#soho-psp-tree-trajectory .button:first, #stereo_a-psp-tree-trajectory .button:first').html('<br>&nbsp;&nbsp;');
-						}
-						
-						// get next encounter
-						if(pspencnum != pspenctotal) {
-							encpagnxt=pspencnum+1;
-							$('#soho-psp-tree-trajectory .button:last, #stereo_a-psp-tree-trajectory .button:last').html(encpagnxt+' &#9654;');
-						}
-						else if(pspencnum == pspenctotal) {
-							$('#soho-psp-tree-trajectory .button:last, #stereo_a-psp-tree-trajectory .button:last').html('&nbsp;&nbsp;');
-						}
-					
-					
-						$('#soho-psp-tree-trajectory .button, #soho-psp-tree-trajectory .decoration').css('display','inline');
-						$('#stereo_a-psp-tree-trajectory .button, #stereo_a-psp-tree-trajectory .decoration').css('display','inline');
-					
-					// END generate encounter "pagination"
-					
-					if(typeof datetimemobModule === 'function') {
-						datetimemobModule();
-					}
-					
+				//hvencpaginationelem[0].parentNode.removeChild(hvencpaginationelem[0]);
+				
+				$(".hover-date-container").removeClass("hvenclabels");
+				
+				$('.hover-date-container').append('<span class="hvenclabels"></span>');
+				//$('#soho-psp-tree-trajectory').append('<span id="hvencpagination">'+pspencnum+'</span>');
+				
+				$('.hvenclabels').html('<br>Encounter '+pspencnum);
+				//document.getElementsByClassName("hover-date-container").innerHTML+= '<br>Encounter '+pspencnum;
+				
+				
+				if(menuenclblexists=='no') {
+					// prepend Encounter label
+					$('#soho-psp-tree-trajectory a, #stereo_a-psp-tree-trajectory a').after('<br><br><ins class="jstree-icon" style="background:none;">&nbsp;</ins><span class="menuenclabel" style="font-family: \'Courier New\',Courier,monospace;">Encounter: </span>');
+					menuenclblexists='yes';
 				}
 				
-			});
-		
-		
-		
+				
+				// START generate encounter "pagination"
+					
+					if(pspencnum == 1) {
+						encdash1='';
+					}
+					else {
+						encdash1=' - ';
+					}
+					
+					if(pspencnum == pspenctotal) {
+						encdash2='';
+					}
+					else {
+						encdash2=' - ';
+					}
+					
+					// show current encounter in the pagination (SOHO)
+					$('#soho-psp-tree-trajectory .decoration').eq(1).html(encdash1+'<span style="border-radius:2px;background:white;color:black;font-weight:bold;">&nbsp;'+pspencnum+'&nbsp;</span>'+encdash2);
+					
+					// show current encounter in the pagination (Stereo A)
+					$('#stereo_a-psp-tree-trajectory .decoration').eq(1).html(encdash1+'<span style="border-radius:2px;background:white;color:black;font-weight:bold;">&nbsp;'+pspencnum+'&nbsp;</span>'+encdash2);
+					
+					// make the first and last .decoration <span> elements blank 
+					$('#soho-psp-tree-trajectory .decoration:first, #soho-psp-tree-trajectory .decoration:last, #stereo_a-psp-tree-trajectory .decoration:first, #stereo_a-psp-tree-trajectory .decoration:last').html('');
+					
+					
+
+					
+					// get previous encounter
+					if(pspencnum != 1) {
+						encpagprev=pspencnum-1;
+						$('#soho-psp-tree-trajectory .button:first, #stereo_a-psp-tree-trajectory .button:first').html('<br><ins class="jstree-icon" style="background:none;">&nbsp;</ins>&#9664; '+encpagprev);
+					}
+					else if(pspencnum == 1) {
+						$('#soho-psp-tree-trajectory .button:first, #stereo_a-psp-tree-trajectory .button:first').html('<br>&nbsp;&nbsp;');
+					}
+					
+					// get next encounter
+					if(pspencnum != pspenctotal) {
+						encpagnxt=pspencnum+1;
+						$('#soho-psp-tree-trajectory .button:last, #stereo_a-psp-tree-trajectory .button:last').html(encpagnxt+' &#9654;');
+					}
+					else if(pspencnum == pspenctotal) {
+						$('#soho-psp-tree-trajectory .button:last, #stereo_a-psp-tree-trajectory .button:last').html('&nbsp;&nbsp;');
+					}
+				
+				
+					$('#soho-psp-tree-trajectory .button, #soho-psp-tree-trajectory .decoration').css('display','inline');
+					$('#stereo_a-psp-tree-trajectory .button, #stereo_a-psp-tree-trajectory .decoration').css('display','inline');
+				
+				// END generate encounter "pagination"
+				
+				if(typeof datetimemobModule === 'function') {
+					datetimemobModule();
+				}
+				
+			}
 			
-		}).fail(function(){
-			console.log('Parker Solar Probe JSON failed');
 		});
 
 	}, 500);


### PR DESCRIPTION
# Summary

Fixes #521 

Caches `soho_psp_json` on page load instead of downloading it every time `showEncounter` is called (which is a lot).

# Testing

Enter the browser versions this change was tested on below.

| browser | version  |
| ------- | -------- |
| firefox | 115.7 |
| chrome  | 120.0.6099.234 |
| safari  | 17.2.1  |
| edge    | untested |
