### PR TITLE
Fix events on minimal ui

### DIFF
--- a/resources/js/Events/HelioviewerEventLayerManager.js
+++ b/resources/js/Events/HelioviewerEventLayerManager.js
@@ -39,18 +39,18 @@ var HelioviewerEventLayerManager = EventLayerManager.extend(
      * Loads initial layers either from URL parameters, saved user settings, or the defaults.
      */
     _loadStartingLayers: function (layers) {
-        var eventLayer, basicParams, self = this;
-
         // Add the event layer
         this.addEventLayer(
             new HelioviewerEventLayer(this._eventLayers.length, this._requestDate, this.viewportScale,
                 'HEK', true, Helioviewer.userSettings.get("state.eventLabels"), {"action": "events", "sources": "HEK", "ar_filter": true})
         );
 
-        this.addEventLayer(
-            new HelioviewerEventLayer(this._eventLayers.length, this._requestDate, this.viewportScale,
-                'CCMC', true, true, {"action": "events", "sources": "CCMC"})
-        );
+        if (outputType != 'minimal') {
+            this.addEventLayer(
+                new HelioviewerEventLayer(this._eventLayers.length, this._requestDate, this.viewportScale,
+                    'CCMC', true, true, {"action": "events", "sources": "CCMC"})
+            );
+        }
     },
 
     /**

--- a/resources/js/UI/EventLayerAccordion.js
+++ b/resources/js/UI/EventLayerAccordion.js
@@ -215,13 +215,15 @@ var EventLayerAccordion = Layer.extend(
         eventsDiv = '<div id="k12-events-visibility-btn-'+id+'" class="k12-eventsVisBtn" title="Toggle visibility of event marker pins" style="display: flex;">'
                     + visibilityBtn
                     + '<p id="k12-events-btn-text" style="margin-left:0.3em;">EVENTS ARE ON<p></div>';
+        
+        let jstree = '<div id=' + treeid + ' style="display: none"></div>';
 
         //Add to accordion
         this.domNode.append(eventsDiv);
+        this.domNode.append(jstree);
 
         this._loadEvents(treeid, apiSource);
 
-        //this.domNode.find("#visibilityAvailableBtn-"+id).click( function(e) {
         this.domNode.find("#k12-events-visibility-btn-"+id).click( function(e) {
             var visState = Helioviewer.userSettings.get("state.eventLayerAvailableVisible");
             if(visState == true){
@@ -307,9 +309,7 @@ var EventLayerAccordion = Layer.extend(
 
         // Function for toggling layer visibility
         toggleVisibility = function (e) {
-            var domNode;
-
-            domNode = $(document).find(".event-container");
+            let domNode = $(document).find(".event-container");
             if ( domNode.css('display') == 'none') {
                 domNode.show();
                 Helioviewer.userSettings.set("state.eventLayerVisible", true);


### PR DESCRIPTION
# Summary

Fixes #527 and #528 

Doesn't load CCMC events in minimal UI. A button is made for each set of events, so the CCMC events added the 2nd overlapping button.

Events were missing due to some missing HTML that the javascript code was looking for.
This was also broken when the CCMC events were added since some of the underlying HTML changed.

# Testing

Enter the browser versions this change was tested on below.

| browser | version  |
| ------- | -------- |
| firefox | 115.7.0esr (64-bit) |
| chrome  | 121.0.6167.139 (Official Build) (arm64) |
| safari  |  17.2.1 (18617.1.17.11.12, 18617) |
| edge    | untested |
