### PR TITLE
Add configurable zoom settings

### DIFF
--- a/index.php
+++ b/index.php
@@ -1397,6 +1397,20 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 						<option value='604800'>1 week</option>
 						<option value='2419200'>28 days</option>
 					</select>
+					<br/>
+
+					<label id="js-zoom-label" for='js-zoom-type' class="jq-tooltip" title="Continuous zoom will smoothly zoom in and out while step zoom will leap between preprogrammed scales.">Zoom Type</label>
+					<select id='js-zoom-type' title="test" name='js-zoom-type'>
+						<option value='continuous'>continuous</option>
+						<option value='step'>step</option>
+					</select>
+					<br/>
+
+					<label id='js-focus-label' for='js-zoom-focus' class="jq-tooltip" title="Focus on mouse will make zoom operations zoom in on the mouse pointer. Focus on center will make zoom operations zoom in to the center of the viewport." >Zoom Focus</label>
+					<select id='js-zoom-focus' name='js-zoom-focus'>
+						<option value='cursor'>Focus on mouse</option>
+						<option value='center'>Focus on center</option>
+					</select>
 				</div>
 				</fieldset>
 			</form>

--- a/resources/js/HelioviewerWebClient.js
+++ b/resources/js/HelioviewerWebClient.js
@@ -382,14 +382,35 @@ var HelioviewerWebClient = HelioviewerClient.extend(
      * initializes event-handlers
      */
     _setupSettingsUI: function () {
-        var form, dateLatest, datePrevious, autorefresh, autoplay, duration, self = this;
+        let self = this;
 
-        form         = $("#helioviewer-settings");
-        dateLatest   = $("#settings-date-latest");
-        datePrevious = $("#settings-date-previous");
-        autorefresh  = $("#settings-latest-image");
-        autoplay     = $("#settings-movie-play-automatic");
-        duration     = $("#settings-movie-duration");
+        let form         = $("#helioviewer-settings");
+        let dateLatest   = $("#settings-date-latest");
+        let datePrevious = $("#settings-date-previous");
+        let autorefresh  = $("#settings-latest-image");
+        let autoplay     = $("#settings-movie-play-automatic");
+        let duration     = $("#settings-movie-duration");
+        let zoom_type    = $("#js-zoom-type");
+        let zoom_focus   = $("#js-zoom-focus");
+        let zoom_label = $('#js-zoom-label')
+        zoom_label.qtip({
+            show: {
+                delay: 0
+            },
+            content: {
+                text: zoom_label.attr('title')
+            },
+        });
+
+        let focus_label = $('#js-focus-label');
+        focus_label.qtip({
+            show: {
+                delay: 0
+            },
+            content: {
+                text: focus_label.attr('title')
+            },
+        })
 
         // Starting date
         if (Helioviewer.userSettings.get("options.date") === "latest") {
@@ -417,6 +438,10 @@ var HelioviewerWebClient = HelioviewerClient.extend(
         // Default movie duration
         duration.val(Helioviewer.userSettings.get("options.movies.duration"));
 
+        // Zoom config
+        zoom_type.val(Helioviewer.userSettings.get('zoom.type'));
+        zoom_focus.val(Helioviewer.userSettings.get('zoom.focus'));
+
         // Event-handlers
         dateLatest.change(function (e) {
             Helioviewer.userSettings.set("options.date", "latest");
@@ -439,7 +464,12 @@ var HelioviewerWebClient = HelioviewerClient.extend(
         duration.change(function () {
             Helioviewer.userSettings.set("options.movies.duration", parseInt(this.value, 10));
         });
-
+        zoom_focus.change(function () {
+            Helioviewer.userSettings.set("zoom.focus", this.value);
+        });
+        zoom_type.change(function () {
+            Helioviewer.userSettings.set("zoom.type", this.value);
+        });
     },
 
     /**

--- a/resources/js/Utility/SettingsLoader.js
+++ b/resources/js/Utility/SettingsLoader.js
@@ -205,6 +205,10 @@ var SettingsLoader = (
                 "celestialBodiesLabelsVisible" : {},
                 "celestialBodiesTrajectoriesVisible" : {}
             },
+            zoom: {
+                type: 'continuous',
+                focus: 'center'
+            },
             version: serverSettings.version
         };
     }


### PR DESCRIPTION
# Summary

Allows users to control the zoom behavior.
If desired, they can re-enable step zoom, and also change zoom to always focus on the center of the viewport, or on the mouse.

# Testing

Enter the browser versions this change was tested on below.

| browser | version  |
| ------- | -------- |
| firefox | 115.7.0esr (64-bit) |
| chrome  | 121.0.6167.139 (Official Build) (arm64) |
| safari  | 17.2.1 (18617.1.17.11.12, 18617) |
| edge    | untested |
