### PR TITLE
Fix some instances of embedded helioviewer

### DIFF
--- a/resources/js/HelioviewerClient.js
+++ b/resources/js/HelioviewerClient.js
@@ -42,9 +42,16 @@ var HelioviewerClient = Class.extend(
      * @description Checks browser support for various features used in Helioviewer
      */
     _checkBrowser: function () {
+        let localStorageSupport = true;
+        try {
+            localStorageSupport = ('localStorage' in window) && window['localStorage'] !== null;
+        } catch (e) {
+            localStorageSupport = false;
+        }
+
         // Base support
         $.extend($.support, {
-            "localStorage" : ('localStorage' in window) && window['localStorage'] !== null,
+            "localStorage" : localStorageSupport,
             "nativeJSON"   : typeof (JSON) !== "undefined",
             "video"        : !!document.createElement('video').canPlayType,
             "h264"         : false,

--- a/resources/js/UI/ImageScale.js
+++ b/resources/js/UI/ImageScale.js
@@ -317,21 +317,20 @@ var ImageScale = Class.extend(
         if ( parseInt(Helioviewer.userSettings.get("state.scaleX")) == 0 ||
              parseInt(Helioviewer.userSettings.get("state.scaleY")) == 0 ) {
 
-
-            if (outputType != 'minimal'){
-
-	            this.containerX = this.container.parent().width()*0.66 - this.container.width()/2; //center the earth container
-	            this.containerY = $('#earth-button').position().top + $('#scale').position().top + this.container.height();
-	            this.scale = false;
-
-	        }else{
-                var sc = $('#scale');
-                this.containerX = sc.position().left + (sc.outerWidth()/2) - this.container.width()/2; //center the earth container
-	            this.containerY = sc.position().top - this.container.height() - 3;
-		        //this.containerX = this.container.parent().width() - 150;
-		        //this.containerY = this.container.parent().height() - 100;
-		        this.scale = true;
-	        }
+            switch(outputType) {
+                case "minimal":
+                case "embed":
+                    var sc = $('#scale');
+                    this.containerX = sc.position().left + (sc.outerWidth()/2) - this.container.width()/2; //center the earth container
+                    this.containerY = sc.position().top - this.container.height() - 3;
+                    this.scale = true;
+                    break;
+                default:
+                    this.containerX = this.container.parent().width()*0.66 - this.container.width()/2; //center the earth container
+                    this.containerY = $('#earth-button').position().top + $('#scale').position().top + this.container.height();
+                    this.scale = false;
+                    break;
+            }
         }
 
         this.scaleContainerDragTo(this.containerX, this.containerY);

--- a/resources/js/UI/ImageScale.js
+++ b/resources/js/UI/ImageScale.js
@@ -236,13 +236,24 @@ var ImageScale = Class.extend(
              Helioviewer.userSettings.get("state.containerY") <= ( $('#hv-header').height() || 0 ) ||
              Helioviewer.userSettings.get("state.containerY") >= this.container.parent().height()-this.container.height()
             ) {
-                this.containerX = this.container.parent().width()*0.66 - this.container.width()/2; //center the earth container
-	            this.containerY = $('#earth-button').position().top + $('#scale').position().top + this.container.height();
-                this.container.css({
-                    'position' : 'absolute',
-                    'top'      : this.containerY+'px',
-                    'left'     : this.containerX+'px'
-                });
+                if (outputType == 'embed') {
+                    this.containerX = 15;
+                    this.containerY = this.container.parent().height() - this.container.height() - 15;
+                    this.container.css({
+                        'position' : 'absolute',
+                        'top'      : this.containerY+'px',
+                        'left'     : this.containerX+'px'
+                    });
+                } else {
+                    this.containerX = this.container.parent().width()*0.66 - this.container.width()/2; //center the earth container
+                    this.containerY = $('#earth-button').position().top + $('#scale').position().top + this.container.height();
+                    this.container.css({
+                        'position' : 'absolute',
+                        'top'      : this.containerY+'px',
+                        'left'     : this.containerX+'px'
+                    });
+                }
+                
             }
         }else{// minimal helioviewer
             var dm = $('#date-manager-container');
@@ -319,11 +330,15 @@ var ImageScale = Class.extend(
 
             switch(outputType) {
                 case "minimal":
-                case "embed":
                     var sc = $('#scale');
                     this.containerX = sc.position().left + (sc.outerWidth()/2) - this.container.width()/2; //center the earth container
                     this.containerY = sc.position().top - this.container.height() - 3;
                     this.scale = true;
+                    break;
+                case "embed":
+                    this.scale = false;
+                    this.containerX = 15;
+                    this.containerY = this.container.parent().height() - this.container.height() - 15;
                     break;
                 default:
                     this.containerX = this.container.parent().width()*0.66 - this.container.width()/2; //center the earth container


### PR DESCRIPTION
# Summary

For #536 

This fixes the "embed" portion of Helioviewer being embedded in pages. The minimal view is still having issues being embedded.

Helioviewer was failing to load because it attempted to access the localStorage object on the window, which was denied. 

Helioviewer was already design to work without localStorage support, but it failed to catch this instance of it not being accessible.

There were also issues positioning the earth scale since some HTML elements that it used as a reference don't exist.

# Testing

Enter the browser versions this change was tested on below.

| browser | version  |
| ------- | -------- |
| firefox | 115.7.0esr (64-bit) |
| chrome  | 122.0.6261.69 (Official Build) (arm64) |
| safari  |  17.2.1 (18617.1.17.11.12, 18617) |
| edge    | untested |
