### PR TITLE
Center viewport before starting the tutorial

### DIFF
--- a/resources/js/Utility/Tutorial.js
+++ b/resources/js/Utility/Tutorial.js
@@ -1,4 +1,6 @@
 function startTutorial(){
+	$(document).trigger("center-viewport");
+
 	if(Helioviewer.userSettings.get("state.drawers.#hv-drawer-left.open") == false){
 		helioviewer.drawerLeftClick(true);
 	}


### PR DESCRIPTION
# Summary

Fixes #510 

The sun will be centered in the viewport when the interactive tutorial begins.

# Testing

Enter the browser versions this change was tested on below.

| browser | version  |
| ------- | -------- |
| firefox | 115.8.0esr (64-bit) |
| chrome  | 122.0.6261.94 |
| safari  |  17.3.1  |
| edge    | untested |
