### PR TITLE
Third level control on feature and events tree with new hovering effects

### DIFF
--- a/index.php
+++ b/index.php
@@ -119,6 +119,7 @@
 		<link rel="stylesheet" href="/resources/css/layout.css" />
 		<link rel="stylesheet" href="/resources/css/accordions.css" />
 		<link rel="stylesheet" href="/resources/css/dialogs.css" />
+		<link rel="stylesheet" href="/resources/css/celestial-bodies.css" />
 		<link rel="stylesheet" href="/resources/css/events.css" />
 		<link rel="stylesheet" href="/resources/css/event-viewer.css" />
 		<link rel="stylesheet" href="/resources/css/media-manager.css" />
@@ -128,7 +129,6 @@
 		<link rel="stylesheet" href="/resources/css/youtube.css" />
 		<link rel="stylesheet" href="/resources/css/font-awesome.min.css" />
 		<link rel="stylesheet" href="/resources/css/helioviewer-views.css" />
-		<link rel="stylesheet" href="/resources/css/celestial-bodies.css" />
 	<?php
 	} else {
 	?>

--- a/resources/css/events.css
+++ b/resources/css/events.css
@@ -27,6 +27,7 @@
     width: 23px;
     transform-origin: bottom;
 }
+
 .event-label, .event-label-hover {
     color: white;
     font-family: Arial, Helvetica, sans-serif;
@@ -47,10 +48,12 @@
     top: 4px;
     white-space: nowrap;
 }
+
 .event-label-hover {
-    background-color: rgba(24, 24, 24, 0.95);
     z-index: 1000;
+    font-size: 13px;
 }
+
 .event-region {
     background-repeat: no-repeat;
     position: absolute;

--- a/resources/js/Events/EventManager.js
+++ b/resources/js/Events/EventManager.js
@@ -40,7 +40,7 @@ var EventManager = Class.extend({
         this._uniqueId = treeid
 
         this.updateRequestTime();
-		setTimeout($.proxy(this._queryEventFRMs, this), 100);
+        setTimeout($.proxy(this._queryEventFRMs, this), 100);
 
         // Set up javascript event handlers
         $(document).bind("fetch-eventFRMs", $.proxy(this._queryEventFRMs, this));
@@ -241,7 +241,6 @@ var EventManager = Class.extend({
                 event_type_arr[0] = event_type_arr[0].slice(0,-1);
             }
 
-            // console.log(event_type_arr);
             obj = Object();
             obj['data']     = event_type_arr[0];
             obj['attr']     = {
@@ -261,7 +260,7 @@ var EventManager = Class.extend({
                 // Generate event instances nodes for jstree
                 let group_children = group.data.map(d => {
                     return {
-                        'data': d.label,
+                        'data': d.short_label ?? d.label,
                         'attr': {
                             'id': self._makeEventInstanceTreeNodeID(event_type_arr[1], group.name, d.id),
                             'hvtype': 'event_instance',
@@ -404,16 +403,16 @@ var EventManager = Class.extend({
 
             checkedFRMs[checkedTypeObj['event_type']] = [];
             $.each ( checkedTypeObj['frms'], function(j, frmName) {
-	            var frmNameChanged = frmName.replace(/\\/g,'');
+                var frmNameChanged = frmName.replace(/\\/g,'');
                 checkedFRMs[checkedTypeObj['event_type']].push(frmNameChanged);
             });
 
             // Iterate on partially selected events under frm
             // we are going to build above state object: notFullySelectedFRMSAndChildrens
             $.each ( checkedTypeObj['event_instances'], function(j, eventInstance) {
-	            var eventInstanceNewName = eventInstance.replace(/\\/g,'');
+                var eventInstanceNewName = eventInstance.replace(/\\/g,'');
                 let parsedFrm = eventInstanceNewName.split("--")[1];
-                
+
                 // Frm for those event_instances, should be included into the visible frm list
                 if(!checkedFRMs[checkedTypeObj['event_type']].includes(parsedFrm)) {
                     checkedFRMs[checkedTypeObj['event_type']].push(parsedFrm);

--- a/resources/js/Events/EventManager.js
+++ b/resources/js/Events/EventManager.js
@@ -511,7 +511,7 @@ var EventManager = Class.extend({
             // this is an frm
             if(parts.length == 2) { 
                 markersToEmphasize = this._eventMarkers.filter(em => {
-                    return em.belongsToFrm(parts[1])
+                    return em.belongsToFrm(parts[1]);
                 });
             }
 

--- a/resources/js/Events/EventMarker.js
+++ b/resources/js/Events/EventMarker.js
@@ -987,7 +987,7 @@ var EventMarker = Class.extend(
      */
     belongsToFrm: function(frmName) {
         // Usually frmNames has _ for space
-        let frmNameNonUnderScored = frmName.replace("_"," ");
+        let frmNameNonUnderScored = frmName.replaceAll("_"," ");
         return this.event.name == frmName || this.event.name == frmNameNonUnderScored;
     },
 

--- a/resources/js/Events/EventMarker.js
+++ b/resources/js/Events/EventMarker.js
@@ -294,11 +294,15 @@ var EventMarker = Class.extend(
 
     setVisibility: function (visible) {
         if (visible) {
-            this.eventRegionDomNode.show();
+            if(this.eventRegionDomNode) {
+                this.eventRegionDomNode.show();
+            }
             this.eventMarkerDomNode.show();
         }
         else {
-            this.eventRegionDomNode.hide();
+            if(this.eventRegionDomNode) {
+                this.eventRegionDomNode.hide();
+            }
             this.eventMarkerDomNode.hide();
         }
     },
@@ -958,7 +962,43 @@ var EventMarker = Class.extend(
 		s = s.replace(/u00b2/g, "²");
 
 		return s;
-    }
+    },
+
+    /**
+     * Emphasize label of the marker, 
+     */
+    emphasize: function() {
+        this.eventMarkerDomNode.css('zIndex', '997');
+        this._label.addClass("event-label-hover");
+    },
+
+    /**
+     * deEmphasize label of the marker, 
+     */
+    deEmphasize: function() {
+        this.eventMarkerDomNode.css('zIndex', this._zIndex);
+        this._label.removeClass("event-label-hover");
+    },
+
+    /**
+     * Checks if the marker belongs to given FRM,
+     * @param {string} frmName, name of FRM, internally handles underscored frmNames as well
+     * @returns {booelan} 
+     */
+    belongsToFrm: function(frmName) {
+        // Usually frmNames has _ for space
+        let frmNameNonUnderScored = frmName.replace("_"," ");
+        return this.event.name == frmName || this.event.name == frmNameNonUnderScored;
+    },
+
+    /**
+     * Checks if the marker belongs to event type,
+     * @param {string} eventType, event type is the pin of event data
+     * @returns {booelan} 
+     */
+    belongsToEventType: function(eventType) {
+        return this.event.pin == eventType;
+    },
 
 });
 

--- a/resources/js/Events/EventMarker.js
+++ b/resources/js/Events/EventMarker.js
@@ -332,7 +332,6 @@ var EventMarker = Class.extend(
         }
 
         if ( event.type == 'toggle-event-label-on' ) {
-            this.eventMarkerDomNode.css('zIndex', '997');
             this._labelVisible = true;
             this._label.show();
             Helioviewer.userSettings.set("state.eventLabels", true);
@@ -340,7 +339,6 @@ var EventMarker = Class.extend(
         else if ( event.type == 'toggle-event-label-off' ) {
             this._labelVisible = false;
             this._label.hide();
-            this.eventMarkerDomNode.css('zIndex', this._zIndex);
             Helioviewer.userSettings.set("state.eventLabels", false);
         }
         else if ( event.type == 'mouseenter' ) {
@@ -357,8 +355,8 @@ var EventMarker = Class.extend(
             if ( !this._labelVisible) {
                 this._label.hide();
             }
-            this._label.removeClass("event-label-hover");
             this.eventMarkerDomNode.css('zIndex', this._zIndex);
+            this._label.removeClass("event-label-hover");
 
             if(Helioviewer.userSettings.get("state.drawers.#hv-drawer-timeline-events.open") == true && timelineRes == 'm'){
 	            $(".highcharts-series > rect").show();

--- a/resources/js/Events/SelectedEventsCache.js
+++ b/resources/js/Events/SelectedEventsCache.js
@@ -7,7 +7,7 @@
 class SelectedEventsCache {
     constructor() {
         /**
-         * Lookup table keyed by the event and the value is the frm list
+         * Lookup table keyed by the event and the value is the frm list and the event_instances list
          */
         this._events = {}
     }
@@ -17,15 +17,32 @@ class SelectedEventsCache {
      * @param {string} eventType Event type to cache
      * @param {string} frm Frm to cache
      */
-    add(eventType, frm) {
+    addFRM(eventType, frm) {
         // If the event type isn't keyed in the event table, then add it
         if (!this._events.hasOwnProperty(eventType)) {
-            this._events[eventType] = [];
+            this._events[eventType] = {frms:[], event_instances:[]};
         }
-        // Remove the item if it exists first to make sure there's only ever one in the list.
-        this.remove(eventType, frm);
-        // Push the frm into the list
-        this._events[eventType].push(frm);
+        // Push the frm into the list, only if it is not already there
+        if(!this._events[eventType].frms.includes(frm)) {
+            this._events[eventType].frms.push(frm)
+        }
+    }
+
+
+    /**
+     * Stores the given eventType, event instance pair
+     * @param {string} eventType Event type to cache
+     * @param {string} eventInstance event instance to cache
+     */
+    addEventInstance(eventType, eventInstance) {
+        // If the event type isn't keyed in the event table, then add it
+        if (!this._events.hasOwnProperty(eventType)) {
+            this._events[eventType] = {frms:[], event_instances:[]};
+        }
+        // Push the event instance into the list, only if it is not already there
+        if(!this._events[eventType]['event_instances'].includes(eventInstance)) {
+            this._events[eventType]['event_instances'].push(eventInstance);
+        }
     }
 
     /**
@@ -33,18 +50,32 @@ class SelectedEventsCache {
      * @param {string} eventType Event type to look for in the cache
      * @param {string} frm FRM to find for the given event type
      */
-    remove(eventType, frm) {
+    removeFRM(eventType, frm) {
         if (this._events.hasOwnProperty(eventType)) {
-            let index = this._events[eventType].indexOf(frm);
+            let index = this._events[eventType].frms.indexOf(frm);
             if (index != -1) {
-                this._events[eventType].splice(index, 1);
+                this._events[eventType].frms.splice(index, 1);
+            }
+        }
+    }
+
+    /**
+     * Removes the given eventType, eventInstance pair from the cache
+     * @param {string} eventType Event type to look for in the cache
+     * @param {string} eventInstance Event Instance to find for the given event type
+     */
+    removeEventInstance(eventType, eventInstance) {
+        if (this._events.hasOwnProperty(eventType)) {
+            let index = this._events[eventType].event_instances.indexOf(eventInstance);
+            if (index != -1) {
+                this._events[eventType].event_instances.splice(index, 1);
             }
         }
     }
 
     /**
      * Returns the cache as an iterable list of event types and frms
-     * The result is something like [{event_type: 'FP', frms: ['frm_a', 'frm_b', etc]}]
+     * The result is something like [{event_type: 'FP', frms: ['frm_a', 'frm_b', etc], event_instances: ['FP--SIDC_Operator--ODU4YjBmYTQxNjJiYjgxN2UxZGNmODdiNzc3MzkzYThkNGM5MDA2NWFjZjhlYjI2ZGE4ZDkwZjNlNDExNmZhYg__']}]
      * @typedef {Array<EventFrmPair>} EventCache
      * @typedef {Object} EventFrmPair
      * @property {string} event_type
@@ -54,7 +85,11 @@ class SelectedEventsCache {
     get() {
         let cached_events = this._events;
         return Object.keys(this._events).map((eventType) => {
-            return {event_type: eventType, frms: cached_events[eventType]}
+            return {
+                event_type: eventType, 
+                frms: [...cached_events[eventType].frms], // copy arrays as we are just exporting it 
+                event_instances: [...cached_events[eventType].event_instances],  // copy array as we are just exporting it
+            }
         })
     }
 }

--- a/resources/js/UI/ImagePresets.js
+++ b/resources/js/UI/ImagePresets.js
@@ -334,7 +334,7 @@ var UserLayersPresets = Class.extend({
         //Add events
         if($('input.item-events').is(':checked')){
 			var eventLayerArray = [];
-			let events = Helioviewer.userSettings.get("state.events");
+			let events = Helioviewer.userSettings.get("state.events_v2");
 	        Object.keys(events).forEach((section) => {
 				eventLayerArray = eventLayerArray.concat(events[section].layers)
 			});

--- a/resources/js/Utility/HelperFunctions.js
+++ b/resources/js/Utility/HelperFunctions.js
@@ -427,6 +427,7 @@ var parseEventString = function (str) {
     return {
         event_type : params[0],
         frms       : frms,
+        event_instances : [],
         open       : Boolean(parseInt(params[2], 10))
     };
 };

--- a/resources/js/Utility/SettingsLoader.js
+++ b/resources/js/Utility/SettingsLoader.js
@@ -161,16 +161,12 @@ var SettingsLoader = (
                         "open": false
                     }
                 },
-                "events": {
+                "events_v2": {
                     "tree_HEK": {
                         "visible": true,
                         "layers": [],
                     },
                     "tree_CCMC": {
-                        "visible": true,
-                        "layers": [],
-                    },
-                    "tree_DONKI": {
                         "visible": true,
                         "layers": [],
                     }

--- a/resources/js/Utility/UserSettings.js
+++ b/resources/js/Utility/UserSettings.js
@@ -337,12 +337,12 @@ var UserSettings = Class.extend(
         }
 
         if (typeof urlSettings.eventLayers != 'undefined' && urlSettings.eventLayers == 'None') {
-            Object.keys(this.get("state.events")).forEach((section) => {
-                this.set("state.events." + section + ".layers", [])
+            Object.keys(this.get("state.events_v2")).forEach((section) => {
+                this.set("state.events_v2." + section + ".layers", [])
             });
         }else if (typeof urlSettings.eventLayers != 'undefined' && urlSettings.eventLayers != '') {
-            Object.keys(this.get("state.events")).forEach((section) => {
-                this.set("state.events." + section + ".layers", this._parseURLStringEvents(urlSettings.eventLayers))
+            Object.keys(this.get("state.events_v2")).forEach((section) => {
+                this.set("state.events_v2." + section + ".layers", this._parseURLStringEvents(urlSettings.eventLayers))
             });
         }
 
@@ -457,7 +457,7 @@ var UserSettings = Class.extend(
 
         if ( typeof eventLayerArray == "undefined" ) {
             eventLayerArray = [];
-            let events = this.get("state.events");
+            let events = this.get("state.events_v2");
             Object.keys(events).forEach((section) => {
                 if (events[section].hasOwnProperty('layers')) {
                     eventLayerArray = eventLayerArray.concat(events[section].layers)


### PR DESCRIPTION
# Summary

- Fixes #543 
- Implements #265 

- implement 3rd level of feature and events tree
- make event cache system to work with current state
- new hovered emphasize mechanism for frms and event_instances
- fix small bug about remembering feature and event states
- change localStorage events keys for current sessions

# Testing

Enter the browser versions this change was tested on below.

| browser | version  |
| ------- | -------- |
| firefox | tested|
| chrome  | tested |
| safari  | tested|
| edge    | tested|
