### PR TITLE
fix half unicode characters in event tree , 3rd label

### DIFF
--- a/resources/js/Events/EventManager.js
+++ b/resources/js/Events/EventManager.js
@@ -258,8 +258,10 @@ var EventManager = Class.extend({
 
                 // Generate event instances nodes for jstree
                 let group_children = group.data.map(d => {
+                    // See Utility/HelperFunctions for fixUnicodeChars
+                    let eventInstanceLabel = d.short_label ?? d.label;
                     return {
-                        'data': d.short_label ?? d.label,
+                        'data': fixUnicodeChars(eventInstanceLabel),
                         'attr': {
                             'id': self._makeEventInstanceTreeNodeID(event_type_arr[1], group.name, d.id),
                             'hvtype': 'event_instance',

--- a/resources/js/Events/EventTree.js
+++ b/resources/js/Events/EventTree.js
@@ -91,7 +91,7 @@ var EventTree = Class.extend({
 
         this._container.jstree({
             "json_data" : { "data": jsTreeData },
-            "core" : { "data": jsTreeData },
+            "core" : { "data": jsTreeData, "html_titles": true },
             "themes"    : { "theme":"default", "dots":true, "icons":false },
             "plugins"   : [ "json_data", "themes", "ui", "checkbox" ],
         });

--- a/resources/js/Utility/HelperFunctions.js
+++ b/resources/js/Utility/HelperFunctions.js
@@ -696,10 +696,6 @@ function formatLyrDateString(tmpLayerDateStr) {
  * @return {string} fixed string
  */
 function fixUnicodeChars(s) {
-    return s.replace(/u03b1/g, "&alpha;")
-        .replace(/u03b2/g, "&beta;")
-        .replace(/u03b3/g, "&gamma;")
-        .replace(/u00b1/g, "&pm;")
-        .replace(/u00b2/g, "&sup;");
+    return s.replace(/u([0-9a-fA-F]{4})/g, "&#x$1;");
 }
 

--- a/resources/js/Utility/HelperFunctions.js
+++ b/resources/js/Utility/HelperFunctions.js
@@ -689,3 +689,17 @@ function formatLyrDateString(tmpLayerDateStr) {
    return frmtTmpDateStr;
 
 }
+
+/*
+ * @description hacky function to fix unicode chars apply to html entities
+ * @param {string} s, string to be fixed
+ * @return {string} fixed string
+ */
+function fixUnicodeChars(s) {
+    return s.replace(/u03b1/g, "&alpha;")
+        .replace(/u03b2/g, "&beta;")
+        .replace(/u03b3/g, "&gamma;")
+        .replace(/u00b1/g, "&pm;")
+        .replace(/u00b2/g, "&sup;");
+}
+


### PR DESCRIPTION
# Summary

Fixes unicode character problem in jstree , event labels.
![2024-05-16 - 14_41_09 -  DEBUG  Helioviewer org - Solar and heliospheric image visualization tool](https://github.com/Helioviewer-Project/helioviewer.org/assets/1138866/91144fcc-6f36-4599-9efc-d0fe8a86ea54)
![2024-05-16 - 14_40_56 -  DEBUG  Helioviewer org - Solar and heliospheric image visualization tool](https://github.com/Helioviewer-Project/helioviewer.org/assets/1138866/17262b90-b3a2-4e2b-8e17-66b3381b0c49)
# Testing

Enter the browsers and the output modes (minimal, normal, embed) this change was tested

| *browser* | *normal* | *minimal* | *embed* | 
| ------- | -------- | -------- | -------- |
| firefox | tested | tested | tested |
| chrome  | tested | tested | tested |
| safari  | untested | untested | untested |
| edge    | tested | tested | tested |
