### PR TITLE
Implement promise cache for closest images and fix bug when merging image layers.

### DIFF
--- a/resources/js/UI/TileLayerAccordion.js
+++ b/resources/js/UI/TileLayerAccordion.js
@@ -871,7 +871,7 @@ var TileLayerAccordion = Layer.extend(
 
             this.closestImages.fetchClosestImageDates(sourceId, self._observationDate).then(function(imgDates) {
 
-                $('[data-source-id="'+oldSourceId+'"]').each((i) => {
+                entry.find('.prev-image-btn').each(function() {
 
                     let prevColor = imgDates.hasPrevImage() ? 'green' : 'red';
                     let prevQtip = imgDates.hasPrevImage() ? 'Prev Image' : 'No Prev Image';
@@ -881,6 +881,12 @@ var TileLayerAccordion = Layer.extend(
                     $(this).attr('title', prevQtip);
                     $(this).css('cursor', prevCursor);
 
+                    $(this).data('sourceId', sourceId);
+
+                });
+
+                entry.find('.next-image-btn').each(function() {
+
                     let nextColor = imgDates.hasNextImage() ? 'green' : 'red';
                     let nextQtip = imgDates.hasNextImage() ? 'Next Image' : 'No Next Image';
                     let nextCursor = imgDates.hasNextImage() ? 'pointer' : 'default';
@@ -888,9 +894,8 @@ var TileLayerAccordion = Layer.extend(
                     $(this).css('color', nextColor);
                     $(this).attr('title', nextQtip);
                     $(this).css('cursor', nextCursor);
-                    
-                    $(this).data('sourceId', sourceId);
 
+                    $(this).data('sourceId', sourceId);
                 });
 
             });

--- a/resources/js/Utility/ClosestImages.js
+++ b/resources/js/Utility/ClosestImages.js
@@ -17,42 +17,39 @@ class ClosestImages {
      */
     fetchClosestImageDates(sourceId, observationDate) {
 
-        let dateStr = observationDate.toISOString();
+        let cacheKey = observationDate.toISOString() + '_' + sourceId;
 
-        if (!this.imageDates.hasOwnProperty(sourceId)) {
-            this.imageDates[sourceId] = {};
-        }
+        if (this.imageDates.hasOwnProperty(cacheKey)) {
 
-        let self = this;
-        let requestPromise = new Promise((resolve, reject) => {
+            return this.imageDates[cacheKey];
 
-            if (self.imageDates[sourceId].hasOwnProperty(dateStr)) {
-                resolve(self.imageDates[sourceId][dateStr]);
-            } else {
-                // Get all nearest image dates
-                $.ajax({
+        } else {
+
+            this.imageDates[cacheKey] = new Promise((resolve, reject) => {
+                return $.ajax({
                     type: "GET",
                     url: Helioviewer.api,
                     dataType: Helioviewer.dataType,
                     data: {
                         "action": "getClosestImageDatesForSources",
                         "sources" : sourceId,
-                        "date": dateStr,
+                        "date": observationDate.toISOString(),
                     },
 
                 }).then((resp) => {
                     let imgLayerDates = new LayerImgDates(resp[sourceId]);
-                    self.imageDates[sourceId][dateStr] = imgLayerDates;
-                    resolve(imgLayerDates);
+                    return resolve(imgLayerDates);
                 }, (error) => {
                     Helioviewer.messageConsole.error("Could not load tile layer controls");
                     console.error(error);
-                    reject(error);
+                    return reject(error);
                 });
-            }
-        });
+            });
 
-        return requestPromise;
+            return this.imageDates[cacheKey];
+
+        }
+
     }
     
     


### PR DESCRIPTION
# Summary

- implement caching promises instead of values for closes images ( <- brilliant idea from Daniel ) 
- fixed layer merge bug happens when you want to switch existing layer into another layer which is already in  image layer stack



