### PR TITLE
Update month/year when updated in flatpickr

### DIFF
--- a/resources/js/Image/JP2Image.js
+++ b/resources/js/Image/JP2Image.js
@@ -163,7 +163,7 @@ var JP2Image = Class.extend(
                 let text = $(notification).find('.jGrowl-message');
                 notification.stop().fadeOut(250, () => {
                     // Update the tet after the old notification has faded out.
-                    text.text(message);
+                    text.html(message);
                     notification.fadeIn(250);
                     // Return the notification instance
                 })
@@ -180,7 +180,7 @@ var JP2Image = Class.extend(
                             // Remove any other duplicate notifications
                             $("." + group).not(msg).remove();
                             resolve(msg);
-                        }, 
+                        },
                         click: (e, m, o) => {
                             return helioviewerWebClient.timeControls.setDate(Date.parseUTCDate(closestImageDate)) && true;
                         }

--- a/resources/js/UI/TimeControls.js
+++ b/resources/js/UI/TimeControls.js
@@ -257,7 +257,6 @@ var TimeControls = Class.extend(
             }
         };
 
-        console.log("Flatpickr initialized")
         this._dateInput._flatpickr = this._dateInput.flatpickr({
             allowInput: true,
             dateFormat: 'Y/m/d',

--- a/resources/js/UI/TimeControls.js
+++ b/resources/js/UI/TimeControls.js
@@ -257,11 +257,22 @@ var TimeControls = Class.extend(
             }
         };
 
+        console.log("Flatpickr initialized")
         this._dateInput._flatpickr = this._dateInput.flatpickr({
             allowInput: true,
             dateFormat: 'Y/m/d',
             disableMobile: true,
-            onChange: $.proxy(this._onTextFieldChange, this)
+            onChange: $.proxy(this._onTextFieldChange, this),
+            onMonthChange: (a, b, flatpickr) => {
+                let date = this.getDate();
+                date.setMonth(flatpickr.currentMonth);
+                this.setDate(date);
+            },
+            onYearChange: (a, b, flatpickr) => {
+                let date = this.getDate();
+                date.setYear(flatpickr.currentYear);
+                this.setDate(date);
+            }
         });
 
         this._dateInput.keydown(createCloseFunction(this._dateInput));


### PR DESCRIPTION
# Summary

Before this change, the Helioviewer date was only updated when you select a specific day of the month in the datepicker.
With this change, updating the month or year will automatically update the observation date.

# Testing

Enter the browsers and the output modes (minimal, normal, embed) this change was tested

| *browser* | *normal* | *minimal* | *embed* | 
| ------- | -------- | -------- | -------- |
| firefox | tested | untested | untested |
| chrome  | untested | untested | untested |
| safari  | tested | untested | untested |
| edge    | untested | untested | untested |
