### PR TITLE
Fix tile loading on the right & bottom of the viewport after zooming out

### DIFF
--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -62,18 +62,21 @@ var TileLayer = Layer.extend(
         // tile size may be x, but if zoomed in or out, it will appear to be x * zoom.
         let scale = (Helioviewer.userSettings.get('mobileZoomScale') || 1);
         let ts = this.tileSize * scale;
+        console.log(scale, this.tileSize, ts);
         // Get the coordinate of this image relative to the origin
         // image.offset is this coordinate of the origin relative to the image center.
         // By changing the sign, it becomes the coordinate of the image center
         // relative to the origin.
         // The origin is the center of the sun / moving container.
         let offset = this.getCurrentOffset();
+        console.log(offset);
         // Computes the coordinates of the nearest tile multiples in each direction.
         // These coordinates are measured relative to the center of the image (offsetX, offsetY).
         // vpCoords are measured relative to sun center, the origin of the moving container.
         // To change the origin to be relative to the image, we have to do the operation vpCoord - (offsetX, offsetY).
-        let vpWidth = (vpCoords.right - vpCoords.left) * scale;
-        let vpHeight = (vpCoords.bottom - vpCoords.top) * scale;
+        let vpWidth = (vpCoords.right - vpCoords.left);
+        let vpHeight = (vpCoords.bottom - vpCoords.top);
+        console.log(vpWidth, vpHeight);
         let shiftedVp = {
             top: vpCoords.top + offset.y,
             left: vpCoords.left + offset.x,

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -62,21 +62,18 @@ var TileLayer = Layer.extend(
         // tile size may be x, but if zoomed in or out, it will appear to be x * zoom.
         let scale = (Helioviewer.userSettings.get('mobileZoomScale') || 1);
         let ts = this.tileSize * scale;
-        console.log(scale, this.tileSize, ts);
         // Get the coordinate of this image relative to the origin
         // image.offset is this coordinate of the origin relative to the image center.
         // By changing the sign, it becomes the coordinate of the image center
         // relative to the origin.
         // The origin is the center of the sun / moving container.
         let offset = this.getCurrentOffset();
-        console.log(offset);
         // Computes the coordinates of the nearest tile multiples in each direction.
         // These coordinates are measured relative to the center of the image (offsetX, offsetY).
         // vpCoords are measured relative to sun center, the origin of the moving container.
         // To change the origin to be relative to the image, we have to do the operation vpCoord - (offsetX, offsetY).
         let vpWidth = (vpCoords.right - vpCoords.left);
         let vpHeight = (vpCoords.bottom - vpCoords.top);
-        console.log(vpWidth, vpHeight);
         let shiftedVp = {
             top: vpCoords.top + offset.y,
             left: vpCoords.left + offset.x,

--- a/tests/desktop/multi/tiles.spec.ts
+++ b/tests/desktop/multi/tiles.spec.ts
@@ -1,44 +1,49 @@
 import { test, expect } from '@playwright/test';
-import { Helioviewer } from '../../page_objects/helioviewer';
+import { HelioviewerViews, InterfaceFor, NormalView } from '../../page_objects/helioviewer_interface';
 
-/**
- * A recurring issue in Helioviewer deals with computing which tiles should
- * be displayed in the viewport based on the screen size, zoom amount, and
- * the image container position. This test verifies that tiles are loaded
- * properly when the viewport region intersects with tile boundaries.
- *
- * This test was written for a bug tiles on the right edge of the viewport
- * are not loaded. This bug was reproducable with the following steps:
- * - Zoom In some amount
- * - Zoom out
- * - Observe that not all tiles are loaded and there are black areas where there should be images.
- *
- * This test verifies that the black space does NOT remain, and that the tile does get loaded
- * when it is dragged into the viewport.
- */
-test('Verify image tiles are loaded when the viewport pans to tile boundaries after zooming in and out', async ({ page }) => {
-    let hv = new Helioviewer(page);
-    await hv.Load();
-    await hv.CloseAllNotifications();
-    // Zoom in to increase the number of tiles.
-    await hv.ZoomIn(4);
-    // Zoom out, to test the zoom out
-    await hv.ZoomOut(1);
-    // Tiles in column x=1 should be visible from y range y=-2 to y=1
-    expect(page.locator("//img[contains(@src, 'x=1&y=-2')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=1&y=-1')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=1&y=0')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=1&y=1')]")).toHaveCount(1);
-    // Same for tiles in column x=2
-    expect(page.locator("//img[contains(@src, 'x=2&y=-2')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=2&y=-1')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=2&y=0')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=2&y=1')]")).toHaveCount(1);
-    // Tiles in row y=1 should be visible from x range x=-3 to x=2
-    expect(page.locator("//img[contains(@src, 'x=-3&y=1')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=-2&y=1')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=-1&y=1')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=0&y=1')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=1&y=1')]")).toHaveCount(1);
-    expect(page.locator("//img[contains(@src, 'x=2&y=1')]")).toHaveCount(1);
+HelioviewerViews.forEach((view) => {
+    /**
+     * A recurring issue in Helioviewer deals with computing which tiles should
+     * be displayed in the viewport based on the screen size, zoom amount, and
+     * the image container position. This test verifies that tiles are loaded
+     * properly when the viewport region intersects with tile boundaries.
+     *
+     * This test was written for a bug tiles on the right edge of the viewport
+     * are not loaded. This bug was reproducable with the following steps:
+     * - Zoom In some amount
+     * - Zoom out
+     * - Observe that not all tiles are loaded and there are black areas where there should be images.
+     *
+     * This test verifies that the black space does NOT remain, and that the tile does get loaded
+     * when it is dragged into the viewport.
+     */
+    test.only(`[${view}] Verify image tiles are loaded when the viewport pans to tile boundaries after zooming in and out`, async ({ page }) => {
+        let hv = InterfaceFor(view, page);
+        await hv.Load("/");
+        // await hv.Load(view.url);
+        await hv.CloseAllNotifications();
+        // Zoom in to increase the number of tiles.
+        await hv.ZoomIn(4);
+        // Zoom out, to test the zoom out
+        await hv.ZoomOut(1);
+        // Tiles in column x=1 should be visible from y range y=-2 to y=1
+        expect(page.locator("//img[contains(@src, 'x=1&y=-2')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=1&y=-1')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=1&y=0')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=1&y=1')]")).toHaveCount(1);
+        // Same for tiles in column x=2
+        expect(page.locator("//img[contains(@src, 'x=2&y=-2')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=2&y=-1')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=2&y=0')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=2&y=1')]")).toHaveCount(1);
+        // Tiles in row y=1 should be visible from x range x=-3 to x=2
+        expect(page.locator("//img[contains(@src, 'x=-3&y=1')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=-2&y=1')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=-1&y=1')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=0&y=1')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=1&y=1')]")).toHaveCount(1);
+        expect(page.locator("//img[contains(@src, 'x=2&y=1')]")).toHaveCount(1);
+    });
+
 });
+

--- a/tests/desktop/multi/tiles.spec.ts
+++ b/tests/desktop/multi/tiles.spec.ts
@@ -20,7 +20,6 @@ HelioviewerViews.forEach((view) => {
     test(`[${view}] Verify image tiles are loaded when the viewport pans to tile boundaries after zooming in and out`, async ({ page }) => {
         let hv = InterfaceFor(view, page);
         await hv.Load("/");
-        // await hv.Load(view.url);
         await hv.CloseAllNotifications();
         // Zoom in to increase the number of tiles.
         await hv.ZoomIn(4);

--- a/tests/desktop/multi/tiles.spec.ts
+++ b/tests/desktop/multi/tiles.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { Helioviewer } from '../../page_objects/helioviewer';
+
+/**
+ * A recurring issue in Helioviewer deals with computing which tiles should
+ * be displayed in the viewport based on the screen size, zoom amount, and
+ * the image container position. This test verifies that tiles are loaded
+ * properly when the viewport region intersects with tile boundaries.
+ *
+ * This test was written for a bug tiles on the right edge of the viewport
+ * are not loaded. This bug was reproducable with the following steps:
+ * - Zoom In some amount
+ * - Zoom out
+ * - Observe that not all tiles are loaded and there are black areas where there should be images.
+ *
+ * This test verifies that the black space does NOT remain, and that the tile does get loaded
+ * when it is dragged into the viewport.
+ */
+test('Verify image tiles are loaded when the viewport pans to tile boundaries after zooming in and out', async ({ page }) => {
+    let hv = new Helioviewer(page);
+    await hv.Load();
+    await hv.CloseAllNotifications();
+    // Zoom in to increase the number of tiles.
+    await hv.ZoomIn(4);
+    // Zoom out, to test the zoom out
+    await hv.ZoomOut(1);
+    // Tiles in column x=1 should be visible from y range y=-2 to y=1
+    expect(page.locator("//img[contains(@src, 'x=1&y=-2')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=1&y=-1')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=1&y=0')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=1&y=1')]")).toHaveCount(1);
+    // Same for tiles in column x=2
+    expect(page.locator("//img[contains(@src, 'x=2&y=-2')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=2&y=-1')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=2&y=0')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=2&y=1')]")).toHaveCount(1);
+    // Tiles in row y=1 should be visible from x range x=-3 to x=2
+    expect(page.locator("//img[contains(@src, 'x=-3&y=1')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=-2&y=1')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=-1&y=1')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=0&y=1')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=1&y=1')]")).toHaveCount(1);
+    expect(page.locator("//img[contains(@src, 'x=2&y=1')]")).toHaveCount(1);
+});

--- a/tests/desktop/multi/tiles.spec.ts
+++ b/tests/desktop/multi/tiles.spec.ts
@@ -17,7 +17,7 @@ HelioviewerViews.forEach((view) => {
      * This test verifies that the black space does NOT remain, and that the tile does get loaded
      * when it is dragged into the viewport.
      */
-    test.only(`[${view}] Verify image tiles are loaded when the viewport pans to tile boundaries after zooming in and out`, async ({ page }) => {
+    test(`[${view}] Verify image tiles are loaded when the viewport pans to tile boundaries after zooming in and out`, async ({ page }) => {
         let hv = InterfaceFor(view, page);
         await hv.Load("/");
         // await hv.Load(view.url);

--- a/tests/desktop/multi/tiles.spec.ts
+++ b/tests/desktop/multi/tiles.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { HelioviewerViews, InterfaceFor, NormalView } from '../../page_objects/helioviewer_interface';
+import { HelioviewerInterfaceFactory, HelioviewerViews } from '../../page_objects/helioviewer_interface';
 
 HelioviewerViews.forEach((view) => {
     /**
@@ -18,7 +18,7 @@ HelioviewerViews.forEach((view) => {
      * when it is dragged into the viewport.
      */
     test(`[${view}] Verify image tiles are loaded when the viewport pans to tile boundaries after zooming in and out`, async ({ page }) => {
-        let hv = InterfaceFor(view, page);
+        let hv = HelioviewerInterfaceFactory.Create(view, page);
         await hv.Load("/");
         await hv.CloseAllNotifications();
         // Zoom in to increase the number of tiles.

--- a/tests/desktop/multi/unmatched_image_warning.spec.ts
+++ b/tests/desktop/multi/unmatched_image_warning.spec.ts
@@ -18,7 +18,7 @@
  */
 import { test, expect } from '@playwright/test';
 
-test('Normal View: Helioviewer shows a warning when the image displayed is at least 6 hours away from the observation time.', async ({ page }) => {
+test('[Normal] Helioviewer shows a warning when the image displayed is at least 6 hours away from the observation time.', async ({ page }) => {
   await page.goto('/');
   // Close the initial notifications that come up
   // The first time visit tutorial & the image warning will show
@@ -50,7 +50,7 @@ test('Normal View: Helioviewer shows a warning when the image displayed is at le
   await expect(page.getByText('The AIA 304 layer is 6 hours')).not.toBeVisible();
 });
 
-test('Minimal View: Helioviewer shows a warning when the image displayed is at least 6 hours away from the observation time.', async ({ page }) => {
+test('[Minimal] Helioviewer shows a warning when the image displayed is at least 6 hours away from the observation time.', async ({ page }) => {
   await page.goto('/?output=minimal');
   // Set the date to 6 hours away from the test image
   await page.getByLabel('Date').click();
@@ -76,7 +76,7 @@ test('Minimal View: Helioviewer shows a warning when the image displayed is at l
   await expect(page.getByText('The AIA 171 layer is 6 hours')).not.toBeVisible();
 });
 
-test('Embedded View: Helioviewer shows a warning when the image displayed is at least 6 hours away from the observation time.', async ({ page }) => {
+test('[Embed] Helioviewer shows a warning when the image displayed is at least 6 hours away from the observation time.', async ({ page }) => {
   await page.goto('?output=embed&date=2024-01-01T00:00:00Z');
   // Expect the warning to appear with the expected text
   await expect(page.getByText('The AIA 304 layer is 943 days')).toBeVisible();

--- a/tests/page_objects/helioviewer.ts
+++ b/tests/page_objects/helioviewer.ts
@@ -13,7 +13,7 @@ import { ImageLayer } from './image_layer';
 interface LayerSelect {
     label: string,
     value: string
-}
+};
 
 class Helioviewer {
     page: Page;
@@ -24,8 +24,8 @@ class Helioviewer {
         this.sidebar = this.page.locator('#hv-drawer-left');
     }
 
-    async Load() {
-        await this.page.goto('/');
+    async Load(path: string = '/') {
+        await this.page.goto(path);
         await this.WaitForLoadingComplete();
     }
 

--- a/tests/page_objects/helioviewer_embed.ts
+++ b/tests/page_objects/helioviewer_embed.ts
@@ -1,0 +1,53 @@
+import { test, expect, Page } from '@playwright/test';
+import { Helioviewer } from './helioviewer';
+import { HelioviewerInterface } from './helioviewer_interface';
+
+/**
+ * Interface for Helioviewer's Embedded view
+ */
+class HelioviewerEmbed implements HelioviewerInterface {
+    /** Playwright page */
+    private page: Page;
+
+    /** Reference to Helioviewer main view for shared code */
+    private hv: Helioviewer;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.hv = new Helioviewer(page);
+    }
+
+    async Load(url: string = "/"): Promise<void> {
+        // Try to add "output=embed" to the given url string.
+        // If there's already a query string, then add output=embed to the end
+        if (url.indexOf("?") != -1) {
+            url = `${url}&output=embed`;
+        }
+        // If there's not a query string, assume we can add one.
+        else {
+            url = `${url}?output=embed`;
+        }
+
+        await this.page.goto(url);
+        await this.page.waitForTimeout(1000);
+        await this.WaitForLoadingComplete();
+    }
+
+    async WaitForLoadingComplete(): Promise<void> {
+        await this.hv.WaitForImageLoad();
+    }
+
+    async CloseAllNotifications(): Promise<void> {
+        await this.hv.CloseAllNotifications();
+    }
+
+    async ZoomIn(steps: number): Promise<void> {
+        await this.hv.ZoomIn(steps);
+    }
+
+    async ZoomOut(steps: number): Promise<void> {
+        await this.hv.ZoomOut(steps);
+    }
+}
+
+export { HelioviewerEmbed }

--- a/tests/page_objects/helioviewer_interface.ts
+++ b/tests/page_objects/helioviewer_interface.ts
@@ -1,0 +1,87 @@
+import { Page } from "@playwright/test";
+import { Helioviewer } from "./helioviewer";
+import { HelioviewerEmbed } from "./helioviewer_embed";
+
+/**
+ * Represents the common functions that should be available in all Helioviewer
+ * interfaces (mobile, embed, minimal, desktop)
+ */
+interface HelioviewerInterface {
+    /**
+     * Loads the given page url.
+     * This function should also wait until the HV application has finished loading.
+     */
+    Load(url?: string): Promise<void>;
+
+    /**
+     * Waits for everything on the page to finish loading.
+     * That is, waits for all images and events to load.
+     *
+     * @note Embed doesn't have a loading spinner, so loading may be flaky.
+     */
+    WaitForLoadingComplete(): Promise<void>;
+
+    /**
+     * Closes all Helioviewer notifications.
+     */
+    CloseAllNotifications(): Promise<void>;
+
+    /**
+     * Zoom in by using the zoom in button
+     * @param steps Number of steps to zoom in. Each step is approximately 2x zoom.
+     */
+    ZoomIn(steps: number): Promise<void>;
+
+    /**
+     * Zoom out using the zoom out button.
+     * @param steps Number of steps to zoom out. Each step is approximately 1/2 zoom.
+     */
+    ZoomOut(steps: number): Promise<void>;
+}
+
+/** View types available for helioviewer */
+type HelioviewerView = "Normal" | "Minimal" | "Embed";
+
+// Add some constants for the strings so we don't need to deal with string
+// literals.
+const NormalView = "Normal";
+const MinimalView = "Minimal";
+const EmbedView = "Embed";
+
+/**
+ * List of all available Helioviewer views.
+ * Iterate over this to create tests that apply to all views.
+ */
+let HelioviewerViews: HelioviewerView[] = [
+    NormalView,
+    MinimalView,
+    EmbedView
+]
+
+/**
+ * Returns an implementation for interacting with the desired helioviewer
+ * interface. This is useful for writing one test case that applies to all views.
+ *
+ * @note If you are targeting a specific view, use that view's constructor directly.
+ *       Only use this for a view-agnostic test that can be run for all views.
+ *       The scope of available functions is limited using the generic interface.
+ * @param view
+ */
+function InterfaceFor(view: HelioviewerView, page: Page): HelioviewerInterface {
+    switch (view) {
+        case EmbedView:
+            return new HelioviewerEmbed(page)
+        // TODO: Implement minimal view interface when needed.
+        default:
+            return new Helioviewer(page);
+    }
+}
+
+export {
+    NormalView,
+    MinimalView,
+    EmbedView,
+    HelioviewerViews,
+    InterfaceFor,
+    HelioviewerInterface
+}

--- a/tests/page_objects/helioviewer_interface.ts
+++ b/tests/page_objects/helioviewer_interface.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import { Helioviewer } from "./helioviewer";
 import { HelioviewerEmbed } from "./helioviewer_embed";
+import { HelioviewerMinimal } from "./helioviewer_minimal";
 
 /**
  * Represents the common functions that should be available in all Helioviewer
@@ -70,10 +71,13 @@ let HelioviewerViews: HelioviewerView[] = [
 function InterfaceFor(view: HelioviewerView, page: Page): HelioviewerInterface {
     switch (view) {
         case EmbedView:
-            return new HelioviewerEmbed(page)
-        // TODO: Implement minimal view interface when needed.
-        default:
+            return new HelioviewerEmbed(page);
+        case MinimalView:
+            return new HelioviewerMinimal(page);
+        case NormalView:
             return new Helioviewer(page);
+        default:
+            throw "Invalid View";
     }
 }
 

--- a/tests/page_objects/helioviewer_interface.ts
+++ b/tests/page_objects/helioviewer_interface.ts
@@ -59,33 +59,36 @@ let HelioviewerViews: HelioviewerView[] = [
     EmbedView
 ]
 
-/**
- * Returns an implementation for interacting with the desired helioviewer
- * interface. This is useful for writing one test case that applies to all views.
- *
- * @note If you are targeting a specific view, use that view's constructor directly.
- *       Only use this for a view-agnostic test that can be run for all views.
- *       The scope of available functions is limited using the generic interface.
- * @param view
- */
-function InterfaceFor(view: HelioviewerView, page: Page): HelioviewerInterface {
-    switch (view) {
-        case EmbedView:
-            return new HelioviewerEmbed(page);
-        case MinimalView:
-            return new HelioviewerMinimal(page);
-        case NormalView:
-            return new Helioviewer(page);
-        default:
-            throw "Invalid View";
+class HelioviewerInterfaceFactory {
+    /**
+     * Returns an implementation for interacting with the desired helioviewer
+     * interface. This is useful for writing one test case that applies to all views.
+     *
+     * @note If you are targeting a specific view, use that view's constructor directly.
+     *       Only use this for a view-agnostic test that can be run for all views.
+     *       The scope of available functions is limited using the generic interface.
+     * @param view
+     */
+    static Create(view: HelioviewerView, page: Page): HelioviewerInterface {
+        switch (view) {
+            case EmbedView:
+                return new HelioviewerEmbed(page);
+            case MinimalView:
+                return new HelioviewerMinimal(page);
+            case NormalView:
+                return new Helioviewer(page);
+            default:
+                throw "Invalid View";
+        }
     }
 }
+
 
 export {
     NormalView,
     MinimalView,
     EmbedView,
     HelioviewerViews,
-    InterfaceFor,
+    HelioviewerInterfaceFactory,
     HelioviewerInterface
 }

--- a/tests/page_objects/helioviewer_minimal.ts
+++ b/tests/page_objects/helioviewer_minimal.ts
@@ -5,7 +5,7 @@ import { HelioviewerInterface } from './helioviewer_interface';
 /**
  * Interface for Helioviewer's Embedded view
  */
-class HelioviewerEmbed implements HelioviewerInterface {
+class HelioviewerMinimal implements HelioviewerInterface {
     /** Playwright page */
     private page: Page;
 
@@ -21,21 +21,20 @@ class HelioviewerEmbed implements HelioviewerInterface {
         // Try to add "output=embed" to the given url string.
         // If there's already a query string, then add output=embed to the end
         if (url.indexOf("?") != -1) {
-            url = `${url}&output=embed`;
+            url = `${url}&output=minimal`;
         }
         // If there's not a query string, assume we can add one.
         else {
-            url = `${url}?output=embed`;
+            url = `${url}?output=minimal`;
         }
 
         await this.page.goto(url);
-        // Wait for 4 image tiles to appear after the page loads
         await expect(this.page.locator('.tile')).toHaveCount(4);
         await this.WaitForLoadingComplete();
     }
 
     async WaitForLoadingComplete(): Promise<void> {
-        await this.hv.WaitForImageLoad();
+        await this.hv.WaitForLoadingComplete();
     }
 
     async CloseAllNotifications(): Promise<void> {
@@ -51,4 +50,4 @@ class HelioviewerEmbed implements HelioviewerInterface {
     }
 }
 
-export { HelioviewerEmbed }
+export { HelioviewerMinimal }


### PR DESCRIPTION
# Summary

Fixes issue with loading tiles after zooming out.

This change also implements a method of testing Normal/Minimal/Embed views with one playwright test.

# Testing

Enter the browsers and the output modes (minimal, normal, embed) this change was tested

| *browser* | *normal* | *minimal* | *embed* | 
| ------- | -------- | -------- | -------- |
| firefox | tested | tested | tested |
| chrome  | tested | tested | tested |
| safari  | tested | tested | tested |
| edge    | tested | tested | tested |
