### PR TITLE
Fix user presets spoil state integer variables 

### DIFF
--- a/resources/js/UI/ImagePresets.js
+++ b/resources/js/UI/ImagePresets.js
@@ -614,30 +614,30 @@ var SystemLayersPresets = [
 		'name':'NOAA flares and active regions',
 		'observationDate':'',
 		'events':'[AR,NOAA_SWPC_Observer,1],[FL,SWPC,1]',
-		'layers':'[SDO,AIA,171,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
+		'layers':'[SDO,AIA,171,1,100,0,60,1,2017/11/16 09:02:20]'
 	},
 	{
 		'name':'Eruption Monitor',
 		'observationDate':'',
 		'events':'[CE,all,1],[ER,all,1],[FI,all,1],[FA,all,1],[FE,all,1]',
-		'layers':'[SDO,AIA,304,1,100,0,60,1,2017-11-16T09:02:20.000Z],[SOHO,LASCO,C2,white-light,1,100,0,60,1,2017-05-18T15:35:00.000Z],[SOHO,LASCO,C3,white-light,1,100,0,60,1,2017-05-18T15:35:00.000Z]'
+		'layers':'[SDO,AIA,304,1,100,0,60,1,2017/11/16 09:02:20],[SOHO,LASCO,C2,white-light,1,100,0,60,1,2017/05/18 15:35:00],[SOHO,LASCO,C3,white-light,1,100,0,60,1,2017/05/18 15:35:00]'
 	},
 	{
 		'name':'Magnetic flux Monitor',
 		'observationDate':'',
 		'events':'[EF,all,1],[SS,all,1]',
-		'layers':'[SDO,HMI,magnetogram,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
+		'layers':'[SDO,HMI,magnetogram,1,100,0,60,1,2017/11/16 09:02:20]'
 	},
 	{
 		'name':'Coronal hole Monitor',
 		'observationDate':'',
 		'events':'[CH,all,1]',
-		'layers':'[SDO,AIA,211,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
+		'layers':'[SDO,AIA,211,1,100,0,60,1,2017/11/16 09:02:20]'
 	},
 	{
 		'name':'Sunspots',
 		'observationDate':'',
 		'events':'[SS,all,1]',
-		'layers':'[SDO,HMI,continuum,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
+		'layers':'[SDO,HMI,continuum,1,100,0,60,1,2017/11/16 09:02:20]'
 	},
 ];

--- a/resources/js/Utility/HelperFunctions.js
+++ b/resources/js/Utility/HelperFunctions.js
@@ -354,8 +354,20 @@ var extractLayerName = function (layer) {
     return layer.split(",").slice(0, -2);
 };
 
+
+/** 
+ * This function takes in a value and converts it to an integer using the parseInt method with a base of 10. 
+ * If the value cannot be converted to an integer, the original value is returned. 
+ * The parameter type is any and the return value is either an integer or the original value.
+ */
+var convertToIntegerOrOriginal = function(value) {
+    const intValue = parseInt(value, 10);
+    return isNaN(intValue) ? value : intValue;
+}
+
+
 /**
- * Breaks up a given layer identifier (e.g. SOHO,LASCO,C2,white-light) into its
+ * Breaks up a given layer identifier ( e.g. SOHO,LASCO,C2,white-light) into its
  * component parts and returns a JavaScript representation.
  *
  * @param {String} The layer identifier as an comma-concatenated string
@@ -401,10 +413,10 @@ var parseLayerString = function (str) {
     return {
         uiLabels    : uiLabels,
         visible     : visible,
-        opacity     : opacity,
-        difference  : difference, 
-        diffCount   : diffCount, 
-        diffTime    : diffTime, 
+        opacity     : convertToIntegerOrOriginal(opacity),
+        difference  : convertToIntegerOrOriginal(difference),
+        diffCount   : convertToIntegerOrOriginal(diffCount),
+        diffTime    : convertToIntegerOrOriginal(diffTime),
         baseDiffTime: baseDiffTime
     };
 };

--- a/tests/desktop/normal/regression/image_preset_spoil_state_integers.spec.ts
+++ b/tests/desktop/normal/regression/image_preset_spoil_state_integers.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { Helioviewer } from '../../../page_objects/helioviewer';
+import * as fs from 'fs';
+
+/**
+ * This test will make Helioviewer load the default AIA 304 image that is
+ * embedded in the development container and perform a visual comparison to make
+ * sure the page appears how we expect it to appear.
+ */
+test('Selecting image presets should not spoil integer state variables', async ({ page }) => {
+
+  let hv = new Helioviewer(page);
+
+  // load helioviewer
+  // Action 1 : BROWSE TO HELIOVIEWER
+  await hv.Load();
+  await hv.CloseAllNotifications();
+
+  // Action 2 : Open left sources panel
+  await hv.ClickDataSourcesTab();
+
+  // Action 3: Load preset Eruption Monitor
+  await hv.SelectImagePreset('Eruption Monitor');
+  await hv.CloseAllNotifications();
+
+  // Action 4: Try to share screen
+  await hv.urlshare.triggerShareURL();
+
+  // Action 5: Check if the shared url is prepared
+  await hv.urlshare.sharedURLIsVisibleAndDone();
+
+});

--- a/tests/page_objects/helioviewer.ts
+++ b/tests/page_objects/helioviewer.ts
@@ -6,6 +6,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { ImageLayer } from './image_layer';
 import { Screenshot } from './screenshot';
 import { Movie } from './movie';
+import { URLShare } from './urlshare';
 
 /**
  * Matches an image layer selection
@@ -25,6 +26,7 @@ class Helioviewer {
         this.page = page;
         this.screenshot = new Screenshot(this.page);
         this.movie = new Movie(this.page);
+        this.urlshare = new URLShare(this.page);
         this.sidebar = this.page.locator('#hv-drawer-left');
     }
 
@@ -204,6 +206,18 @@ class Helioviewer {
     async assertNotification(type: string, message:string) {
         await expect(this.page.locator('div.jGrowl-notification.'+type+' > div.jGrowl-message').getByText(message)).toBeVisible();
     }
+
+    /*
+    * Opens the presets menu and selects the given preset and waits for layers to load.
+    * @param preset string - The name of the preset to be selected.
+    * @returns void
+    */
+    async SelectImagePreset(preset: string) {
+        await this.page.locator('.layersPresetsList .dropdown-main').click();
+        await this.page.getByRole('link', { name: preset }).click();
+        await this.WaitForLoadingComplete();
+    }
+
 
 }
 

--- a/tests/page_objects/urlshare.ts
+++ b/tests/page_objects/urlshare.ts
@@ -1,0 +1,33 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Interface for interacting with url sharing elements
+ */
+class URLShare {
+    /** Playwright page instance */
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    /**
+     * Clicks the button for making shared urls
+     * @return void
+     */
+    async triggerShareURL() {
+        await this.page.locator('#share-button').click();
+    };
+
+    /**
+     * Assert share url is visible
+     * @return void
+     */
+    async sharedURLIsVisibleAndDone() {
+        await expect(this.page.locator('#helioviewer-share-url')).toBeInViewport();
+        await expect(this.page.locator('#helioviewer-share-url')).toHaveValue(new RegExp('https?:\/\/[a-z0-9\-\.:]+\/load\/[a-z0-9A-Z]+'));
+    };
+
+}
+
+export { URLShare }


### PR DESCRIPTION
- Add function to parse strings as integers and use them if it can make them integer, if not string
- Change dates of presets, align them to be valid for api validation when creating urls to share
- Add playwright regression tests to validate bug is fixed

