### PR TITLE
Make baseDiffTime use format Y-m-dTH:M:S.000Z

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
   jest-unit-tests:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: ['18.x']
-
     steps:
     - uses: actions/checkout@v3
     # Setup java for access to `ant`
@@ -38,6 +34,10 @@ jobs:
     - name: Prettier check (certain files)
       run: npx prettier -c resources/js/test resources/js/Media/VideoPlayer.jsx
   playwright-e2e-tests:
+    strategy:
+      matrix:
+        shard: ['1/2', '2/2']
+
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -99,7 +99,7 @@ jobs:
     - name: Run Playwright tests
       run: |
         cd helioviewer.org
-        npx playwright test
+        npx playwright test --shard=${{matrix.shard}}
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
   playwright-e2e-tests:
     strategy:
       matrix:
-        shard: ['1/2', '2/2']
+        shard: ['1/4', '2/4', '3/4', '4/4']
 
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
   playwright-e2e-tests:
     strategy:
       matrix:
-        shard: ['1/4', '2/4', '3/4', '4/4']
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
 
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -99,10 +100,10 @@ jobs:
     - name: Run Playwright tests
       run: |
         cd helioviewer.org
-        npx playwright test --shard=${{matrix.shard}}
+        npx playwright test --shard=${{matrix.shardIndex}}/${{matrix.shardTotal}}
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: playwright-report
+        name: playwright-report-${{matrix.shardIndex}}
         path: helioviewer.org/playwright-report/
-        retention-days: 30
+        retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ const Platforms = {
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  timeout: 600000,
+  timeout: 300000,
   testDir: './tests',
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/resources/js/Tiling/Layer/TileLayer.js
+++ b/resources/js/Tiling/Layer/TileLayer.js
@@ -307,8 +307,7 @@ var TileLayer = Layer.extend(
 	    if(typeof baseDiffTime == 'number' || baseDiffTime == null){
 			baseDiffTime = $('#date').val()+' '+$('#time').val();
 		}
-        this.baseDiffTime = baseDiffTime;
-        //this.tileLoader.reloadTiles(true);
+        this.baseDiffTime = formatLyrDateString(baseDiffTime);
     },
 
     /**

--- a/resources/js/Tiling/Manager/TileLayerManager.js
+++ b/resources/js/Tiling/Manager/TileLayerManager.js
@@ -81,7 +81,7 @@ var TileLayerManager = LayerManager.extend(
                 layerHierarchy[i]['difference'] = parseInt($('#'+idBase+' .layer-select-difference').val());
                 layerHierarchy[i]['diffCount'] = parseInt($('#'+idBase+' .layer-select-difference-period-count').val());
                 layerHierarchy[i]['diffTime'] = parseInt($('#'+idBase+' .layer-select-difference-period').val());
-                layerHierarchy[i]['baseDiffTime'] = $('#'+idBase+' .diffdate').val()+' '+$('#'+idBase+' .difftime').val();
+                layerHierarchy[i]['baseDiffTime'] = formatLyrDateString($('#'+idBase+' .diffdate').val()+' '+$('#'+idBase+' .difftime').val());
 
                 if ( $(accordion).find('.visible').hasClass('hidden') ) {
                     layerHierarchy[i]['visible'] = false;

--- a/resources/js/UI/ImagePresets.js
+++ b/resources/js/UI/ImagePresets.js
@@ -614,30 +614,30 @@ var SystemLayersPresets = [
 		'name':'NOAA flares and active regions',
 		'observationDate':'',
 		'events':'[AR,NOAA_SWPC_Observer,1],[FL,SWPC,1]',
-		'layers':'[SDO,AIA,171,1,100,0,60,1,2017/11/16 09:02:20]'
+		'layers':'[SDO,AIA,171,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
 	},
 	{
 		'name':'Eruption Monitor',
 		'observationDate':'',
 		'events':'[CE,all,1],[ER,all,1],[FI,all,1],[FA,all,1],[FE,all,1]',
-		'layers':'[SDO,AIA,304,1,100,0,60,1,2017/11/16 09:02:20],[SOHO,LASCO,C2,white-light,1,100,0,60,1,2017/05/18 15:35:00],[SOHO,LASCO,C3,white-light,1,100,0,60,1,2017/05/18 15:35:00]'
+		'layers':'[SDO,AIA,304,1,100,0,60,1,2017-11-16T09:02:20.000Z],[SOHO,LASCO,C2,white-light,1,100,0,60,1,2017-05-18T15:35:00.000Z],[SOHO,LASCO,C3,white-light,1,100,0,60,1,2017-05-18T15:35:00.000Z]'
 	},
 	{
 		'name':'Magnetic flux Monitor',
 		'observationDate':'',
 		'events':'[EF,all,1],[SS,all,1]',
-		'layers':'[SDO,HMI,magnetogram,1,100,0,60,1,2017/11/16 09:02:20]'
+		'layers':'[SDO,HMI,magnetogram,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
 	},
 	{
 		'name':'Coronal hole Monitor',
 		'observationDate':'',
 		'events':'[CH,all,1]',
-		'layers':'[SDO,AIA,211,1,100,0,60,1,2017/11/16 09:02:20]'
+		'layers':'[SDO,AIA,211,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
 	},
 	{
 		'name':'Sunspots',
 		'observationDate':'',
 		'events':'[SS,all,1]',
-		'layers':'[SDO,HMI,continuum,1,100,0,60,1,2017/11/16 09:02:20]'
+		'layers':'[SDO,HMI,continuum,1,100,0,60,1,2017-11-16T09:02:20.000Z]'
 	},
 ];

--- a/resources/js/UI/TileLayerAccordion.js
+++ b/resources/js/UI/TileLayerAccordion.js
@@ -856,10 +856,10 @@ var TileLayerAccordion = Layer.extend(
             if(typeof baseDiffTime == 'number' || baseDiffTime == null){
                 var baseDiffTime = $('#date').val()+' '+$('#time').val();
             }
-            var diffDate = baseDiffTime.toString().split(" ");
+            var diffDate = baseDiffTime.toString().split("T");
             if ($('#'+id+' .diffdate').length > 0) {
                 $('#'+id+' .diffdate')[0]._flatpickr.setDate(diffDate[0]);
-                $('#'+id+' .difftime')[0]._flatpickr.setDate(diffDate[1]);
+                $('#'+id+' .difftime')[0]._flatpickr.setDate(diffDate[1].substring(0, 9));
             }
             // $('#'+id+' .difftime').TimePickerAlone('setValue', diffDate[1]);
         }else{

--- a/resources/js/UI/TileLayerAccordion.js
+++ b/resources/js/UI/TileLayerAccordion.js
@@ -293,8 +293,8 @@ var TileLayerAccordion = Layer.extend(
                 var baseDiffTime = helioviewerWebClient.getDate().toISOString();
             }
             var diffDate = baseDiffTime.toString().split("T");
-            $('#'+id+' .diffdate')[0]._flatpickr.setDate(diffDate[0]);
-            $('#'+id+' .difftime')[0]._flatpickr.setDate(diffDate[1].substring(0, 9));
+            $('#'+id+' .diffdate').val(diffDate[0]);
+            $('#'+id+' .difftime').val(diffDate[1].substring(0, 9));
         }else{
             $('#'+id+' .layer-select-difference').val('0');
             $('#'+id+' .difference-type1-block').hide();

--- a/resources/js/UI/TileLayerAccordion.js
+++ b/resources/js/UI/TileLayerAccordion.js
@@ -290,13 +290,11 @@ var TileLayerAccordion = Layer.extend(
             $('#'+id+' .difference-type1-block').hide();
             $('#'+id+' .difference-type2-block').show();
             if(typeof baseDiffTime == 'number' || baseDiffTime == null){
-                var baseDiffTime = $('#date').val()+' '+$('#time').val();
+                var baseDiffTime = helioviewerWebClient.getDate().toISOString();
             }
-            var diffDate = baseDiffTime.toString().split(" ");
-
-            $('#'+id+' .diffdate').val("2022/11/30");//.change();
-            $('#'+id+' .difftime').val(diffDate[1]);//.change();
-            //$('#'+id+' .difftime').TimePickerAlone('setValue', diffDate[1]);
+            var diffDate = baseDiffTime.toString().split("T");
+            $('#'+id+' .diffdate')[0]._flatpickr.setDate(diffDate[0]);
+            $('#'+id+' .difftime')[0]._flatpickr.setDate(diffDate[1].substring(0, 9));
         }else{
             $('#'+id+' .layer-select-difference').val('0');
             $('#'+id+' .difference-type1-block').hide();

--- a/resources/js/Utility/UserSettings.js
+++ b/resources/js/Utility/UserSettings.js
@@ -50,7 +50,7 @@ var UserSettings = Class.extend(
         } catch (e) {
             return false;
         }
-    }, 
+    },
 
     /**
      * Gets a specified setting
@@ -326,6 +326,24 @@ var UserSettings = Class.extend(
         else {
             this.settings = this.cookies.get("settings");
         }
+        // Fix base diff time if it's using an invalid format.
+        this._patchBaseDiffTime();
+    },
+
+    /**
+     * baseDiffTime should be in the format Y-m-dTH:i:s.###Z.
+     * Setting the basedifftime date in the UI previously changed this
+     * to the format Y/m/d H:i:s.
+     * We're trying to normalize the dates to use a consistent format,
+     * so if the old format is here, change it to the new format.
+     */
+    _patchBaseDiffTime: function () {
+        let layers = this.settings.state.tileLayers;
+        for (let i = 0; i < layers.length; i++) {
+            let layer = layers[i];
+            layer.baseDiffTime = formatLyrDateString(layer.baseDiffTime);
+        }
+        this._save();
     },
 
 
@@ -362,7 +380,7 @@ var UserSettings = Class.extend(
             });
         }
 
-        // If any historical shared url turns off event labels, we also respect that 
+        // If any historical shared url turns off event labels, we also respect that
         if ( typeof urlSettings.eventLabels != 'undefined' && urlSettings.eventLabels == false) {
             // We also turning labels off for all layers
             Object.keys(this.get("state.events_v2")).forEach((section) => {
@@ -436,11 +454,7 @@ var UserSettings = Class.extend(
 
             if(typeof layerObj.baseDiffTime != 'undefined'){
 	            var layerDateStr = layerObj.baseDiffTime;
-	            if(typeof layerDateStr == 'number' || layerDateStr == null){
-					var baseDiffTime = $('#date').val()+' '+$('#time').val();
-				}
-
-	            layerString += layerDateStr.replace(' ', 'T').replace(/\//g, '-') + '.000Z';
+	            layerString += formatLyrDateString(layerDateStr);
             }else{
 	            layerString += "";
             }
@@ -533,7 +547,7 @@ var UserSettings = Class.extend(
     },
 
     /*
-     * @description This function is used to update/add state variables to this event_layer state, 
+     * @description This function is used to update/add state variables to this event_layer state,
      * @param {string} id of the event layer
      * @param {string} key
      * @param {any} value
@@ -547,10 +561,10 @@ var UserSettings = Class.extend(
     },
 
     /*
-     * @description This function is used to get/read state variables to this event_layer state, 
+     * @description This function is used to get/read state variables to this event_layer state,
      * @param {string} id of the event layer
      * @param {string} key
-     * @return {any} 
+     * @return {any}
      */
     getHelioViewerEventLayerSettingsValue: function (treeID, key) {
         let treeConf = this.getHelioViewerEventLayerSettings(treeID);
@@ -558,11 +572,11 @@ var UserSettings = Class.extend(
     },
 
     /*
-     * @description This function is used to get/read all state variables to this event_layer state, 
+     * @description This function is used to get/read all state variables to this event_layer state,
      * it also keeps existing states aligned with the new states, it adds keys with default values if they are not in old state
      * @param {string} id of the event layer
      * @param {string} key
-     * @return {JSON}   
+     * @return {JSON}
      */
     getHelioViewerEventLayerSettings: function (treeID) {
 
@@ -602,7 +616,7 @@ var UserSettings = Class.extend(
     /*
      * @description Supplies iterator to traverse all event_layer configuration with given function
      * @param {func} it , iterator function, will be executed for each event layer
-     * @return {void} 
+     * @return {void}
      */
     iterateOnHelioViewerEventLayerSettings: function(it) {
         Object.values(Helioviewer.userSettings.get('state.events_v2')).forEach(it);

--- a/resources/js/Utility/UserSettings.js
+++ b/resources/js/Utility/UserSettings.js
@@ -260,6 +260,8 @@ var UserSettings = Class.extend(
         else {
             this._loadSavedSettings();
         }
+        // Fix base diff time if it's using an invalid format.
+        this._patchBaseDiffTime();
 
         // If version is out of date, load defaults
         if (this.get('version') < this._defaults.version) {
@@ -326,8 +328,6 @@ var UserSettings = Class.extend(
         else {
             this.settings = this.cookies.get("settings");
         }
-        // Fix base diff time if it's using an invalid format.
-        this._patchBaseDiffTime();
     },
 
     /**

--- a/tests/desktop/normal/image_layers.spec.ts
+++ b/tests/desktop/normal/image_layers.spec.ts
@@ -20,3 +20,35 @@ test('Can add and remove image layers', async ({ page }) => {
   // Expect AIA 304 Layer to be present
   await hv.ExpectLayer(1, "AIA 304", "SDO", "AIA", "304");
 });
+
+/**
+ * Image presets have an effect on the application state.
+ * After setting presets, we should be able to share the viewport.
+ * Test Steps:
+ *   0. Load page
+ *   1. Create the LASCO C2 Layer
+ *   2. Close the AIA layer (LASCO C2 has enough images for difference images, AIA does not.)
+ *   3. Set the diffDate date
+ *   4. Set the diffDate time
+ *   5. Share Viewport
+ */
+test.only('Verify that you can share state after setting baseDiffTime', async ({page}) => {
+  // 0. Load page
+  let hv = new Helioviewer(page);
+  await hv.Load();
+  await hv.CloseAllNotifications();
+  await hv.ClickDataSourcesTab();
+  await hv.UseNewestImage();
+  // 1/2. Create the LASCO C2 Layer, Remove the AIA layer
+  await hv.AddImageLayer();
+  await hv.RemoveImageLayer(0);
+  // Expect LASCO C2 Layer to be present
+  await hv.ExpectLayer(0, "LASCO C2", "SOHO", "LASCO", "white-light");
+  // 3/4. Set diffDate date/time
+  let layer = await hv.getImageLayer(0);
+  await layer.set("Difference", "Base difference");
+  await layer.setBaseDifferenceDate('2023/12/01', '00:30:00');
+  // 5. Share viewport
+  await hv.urlshare.triggerShareURL();
+  await hv.urlshare.sharedURLIsVisibleAndDone();
+});

--- a/tests/desktop/normal/image_layers.spec.ts
+++ b/tests/desktop/normal/image_layers.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { Helioviewer } from '../../page_objects/helioviewer';
 
 /**
@@ -32,7 +32,7 @@ test('Can add and remove image layers', async ({ page }) => {
  *   4. Set the diffDate time
  *   5. Share Viewport
  */
-test.only('Verify that you can share state after setting baseDiffTime', async ({page}) => {
+test('Verify that you can share state after setting baseDiffTime', async ({page}) => {
   // 0. Load page
   let hv = new Helioviewer(page);
   await hv.Load();
@@ -51,4 +51,73 @@ test.only('Verify that you can share state after setting baseDiffTime', async ({
   // 5. Share viewport
   await hv.urlshare.triggerShareURL();
   await hv.urlshare.sharedURLIsVisibleAndDone();
+});
+
+/**
+ * This tests that users can safely upgrade from baseDiffDates in the format "Y/m/d H:M:S"
+ * to the ISO format "Y-m-dTH:M:S.###Z".
+ * Old dates in storage will be automatically upgraded.
+ * This test involves manipulating local storage.
+ * Test Steps:
+ *   1. Load helioviewer
+ *   2. Set localStorage to have the LASCO C2 Layer with the old baseDiffTime format.
+ *   3. Reload the page to load with the old format.
+ *   4. Attempt to share the viewport
+ *   5. Check that the baseDiffField values are correct
+ */
+test('Verify that you can share state after upgrading from old baseDiffDate format', async ({page}) => {
+  // 1. Load page
+  let hv = new Helioviewer(page);
+  await hv.Load();
+  // 2. Update localStorage
+  await page.evaluate(() => {
+    window.Helioviewer.userSettings.set("state.tileLayers", [
+        {
+          "baseDiffTime": "2023/12/01 00:30:00",
+          "Detector": "C2",
+          "diffCount": 60,
+          "difference": 2,
+          "diffTime": 1,
+          "end": "2023-12-01 00:48:07",
+          "Instrument": "LASCO",
+          "layeringOrder": 2,
+          "Measurement": "white-light",
+          "nickname": "LASCO C2",
+          "Observatory": "SOHO",
+          "opacity": 100,
+          "sourceId": 4,
+          "start": "2023-12-01 00:00:07",
+          "uiLabels": [
+            {
+              "label": "Observatory",
+              "name": "SOHO"
+            },
+            {
+              "label": "Instrument",
+              "name": "LASCO"
+            },
+            {
+              "label": "Detector",
+              "name": "C2"
+            },
+            {
+              "label": "Measurement",
+              "name": "white-light"
+            }
+          ],
+          "visible": "1"
+        }
+      ]);
+  })
+  // 3. Reload the page
+  await hv.Load();
+  // 4. Try Share viewport
+  await hv.urlshare.triggerShareURL();
+  await hv.urlshare.sharedURLIsVisibleAndDone();
+  // 5. Check that values are correct
+  let layer = await hv.getImageLayer(0);
+  let date = await layer.getBaseDifferenceDate();
+  expect(date).toBe('2023/12/01');
+  let time = await layer.getBaseDifferenceTime();
+  expect(time).toBe('00:30:00');
 });

--- a/tests/desktop/normal/urlsharing.spec.ts
+++ b/tests/desktop/normal/urlsharing.spec.ts
@@ -62,7 +62,7 @@ test('Shared URLs should produce pages, exactly like they shared', async ({ page
   await hv.WaitForImageLoad();
 
 
-  // Now it has to be visible 
+  // Now it has to be visible
   await expect(page.locator('#helioviewer-url-box-stale-link-msg')).toBeVisible();
 
   await page.locator('#update-share-url-link').click();
@@ -95,4 +95,3 @@ test('Shared URLs should produce pages, exactly like they shared', async ({ page
 
   await expect(afterScreenshot).toBe(myScreenshot);
 });
-

--- a/tests/mobile/hello_mobile.spec.ts
+++ b/tests/mobile/hello_mobile.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test';
+import { HvMobile } from '../page_objects/mobile_hv';
 
 test('Mobile - Displays initial AIA 304 Image', async ({ page }) => {
-  await page.goto('/');
-  await page.locator('.hvbottombar').getByText('NEWEST').click();
-  // TODO: Mobile doesn't have a loading indicator we can wait on.
-  await page.waitForTimeout(5000);
+  let mobile = new HvMobile(page);
+  await mobile.Load();
+  await mobile.UseNewestImage();
+  await mobile.WaitForLoad();
   await expect(page).toHaveScreenshot();
 });

--- a/tests/page_objects/helioviewer.ts
+++ b/tests/page_objects/helioviewer.ts
@@ -21,6 +21,9 @@ interface LayerSelect {
 class Helioviewer {
     page: Page;
     sidebar: Locator;
+    screenshot: Screenshot;
+    movie: Movie;
+    urlshare: URLShare;
 
     constructor(page) {
         this.page = page;
@@ -196,7 +199,7 @@ class Helioviewer {
             await this.page.waitForTimeout(500);
         }
     }
-   
+
     /**
      * Assert some certain notification is visible to the application user
      * @param type string, this can be one of the "warn", "error", "info", "success"

--- a/tests/page_objects/image_layer.ts
+++ b/tests/page_objects/image_layer.ts
@@ -98,6 +98,14 @@ class ImageLayer {
         await this.layer_controls.getByLabel('Time', { exact: true }).press('Enter');
     }
 
+    async getBaseDifferenceDate(): Promise<string> {
+        return await this.layer_controls.getByLabel('Base difference').inputValue();
+    }
+
+    async getBaseDifferenceTime(): Promise<string> {
+        return await this.layer_controls.getByLabel('Time', { exact: true }).inputValue();
+    }
+
     /**
      * Returns the given image tile (img tag)
      */

--- a/tests/page_objects/image_layer.ts
+++ b/tests/page_objects/image_layer.ts
@@ -91,6 +91,13 @@ class ImageLayer {
         await this.page.waitForTimeout(500);
     }
 
+    async setBaseDifferenceDate(date: string, time: string) {
+        await this.layer_controls.getByLabel('Base difference').fill(date);
+        await this.layer_controls.getByLabel('Base difference').press('Enter');
+        await this.layer_controls.getByLabel('Time', { exact: true }).fill(time);
+        await this.layer_controls.getByLabel('Time', { exact: true }).press('Enter');
+    }
+
     /**
      * Returns the given image tile (img tag)
      */


### PR DESCRIPTION
# Summary

Fixes an issue where baseDiffTime is sometimes using date formats like "Y/m/d" and other times "Y-m-d".

# Testing

Tested with playwright.
