### PR TITLE
Youtube shared videos playwright tests

### DIFF
--- a/index.php
+++ b/index.php
@@ -722,7 +722,7 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 								<div id="user-video-gallery-main-current">
 									<span id="user-video-gallery-spinner-current"></span>
 								</div>
-								<p class="js-no-movies" style="display: none;">No shared movies found.</p>
+								<p class="js-no-movies" style="display: none;">No movies found around the observation date.</p>
 							</div>
 						</div>
 					</div>
@@ -741,6 +741,7 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 								<div id="user-video-gallery-main">
 									<span id="user-video-gallery-spinner"></span>
 								</div>
+								<p class="js-no-movies" style="display: none;">No shared movies found.</p>
 							</div>
 						</div>
 					</div>

--- a/resources/js/UI/UserVideoGallery.js
+++ b/resources/js/UI/UserVideoGallery.js
@@ -387,7 +387,7 @@ var UserVideoGallery = Class.extend(
 
         if($('.user-video-thumbnail-container-recent').length == 0){
             this._noSharedMoviesFound.show();
-         else {
+        } else {
             this._noSharedMoviesFound.hide();
         }
 

--- a/resources/js/UI/UserVideoGallery.js
+++ b/resources/js/UI/UserVideoGallery.js
@@ -20,7 +20,8 @@ var UserVideoGallery = Class.extend(
     init : function (url) {
         this._container   			= $("#user-video-gallery-main");
         this._containerCurrent   	= $("#user-video-gallery-main-current");
-        this._noSharedMoviesFound   = $("#user-video-gallery-current .js-no-movies");
+        this._noSharedMoviesFound   = $("#user-video-gallery .js-no-movies");
+        this._noSharedMoviesFoundForObservationDate   = $("#user-video-gallery-current .js-no-movies");
         this._loader      			= $("#user-video-gallery-spinner");
         this._loaderCurrent      	= $("#user-video-gallery-spinner-current");
 
@@ -262,9 +263,15 @@ var UserVideoGallery = Class.extend(
 	        count++;
         });
 
-		if($('.user-video-thumbnail-container-recent').length == 0){
+        if($('.user-video-thumbnail-container-current').length == 0){
+            this._noSharedMoviesFoundForObservationDate.show();
+        } else {
+            this._noSharedMoviesFoundForObservationDate.hide();
+        }
+
+        if($('.user-video-thumbnail-container-recent').length == 0){
             this._noSharedMoviesFound.show();
-		} else {
+        } else {
             this._noSharedMoviesFound.hide();
         }
 
@@ -370,12 +377,18 @@ var UserVideoGallery = Class.extend(
         }
 
 		if($('.user-video-thumbnail-container-current').length == 0){
-            this._noSharedMoviesFound.show();
+            this._noSharedMoviesFoundForObservationDate.show();
 		} else {
-            this._noSharedMoviesFound.hide();
+            this._noSharedMoviesFoundForObservationDate.hide();
             if(count == this._numVideosCurrent){
                 this._containerCurrent.append('<span class="user-video-current-show-more">SHOW MORE</span>');
             }
+        }
+
+        if($('.user-video-thumbnail-container-recent').length == 0){
+            this._noSharedMoviesFound.show();
+         else {
+            this._noSharedMoviesFound.hide();
         }
 
 	    $('#user-video-gallery-main-current > div').off();

--- a/tests/desktop/normal/news_announcements.spec.ts
+++ b/tests/desktop/normal/news_announcements.spec.ts
@@ -94,7 +94,7 @@ test("News button should display/hide project news and announcements", async ({ 
   // 4. CLICK NEWS BUTTON TO HIDE NEWS
   await hv.toggleNewsAndAnnouncements();
 
-  // 5. ASSERT TEXT FROM FAKE NEWS SHOULD BE VISIBLE
+  // 5. ASSERT TEXT FROM FAKE NEWS SHOULD NOT BE VISIBLE
   await expect(page.getByText("Foo announcement 1")).not.toBeVisible();
   await expect(page.getByText("2001-01-01 01:01:01.000Z UTC")).not.toBeVisible();
   await expect(page.getByText("Foo announcement summary 1")).not.toBeVisible();

--- a/tests/desktop/normal/news_announcements.spec.ts
+++ b/tests/desktop/normal/news_announcements.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+import { Helioviewer } from "../../page_objects/helioviewer";
+
+/**
+ * This test tests new and announcements viewing functionality with
+ * - load helioviewer
+ * - press news button
+ * - you should see the prefaked news we mock
+ * - press news button again
+ * - you should NOT see the prefaked news we mock
+ */
+test("News button should display/hide project news and announcements", async ({ page }, info) => {
+  let hv = new Helioviewer(page, info);
+
+  // Mock news request
+  const fakeNews = [
+    {
+      title: "Foo announcement 1",
+      link: "https://foo-1.com",
+      published: new Date("2001-01-01T01:01:01Z").toISOString(),
+      updated: new Date("2001-01-01T01:01:01Z").toISOString(),
+      id: "foo-id-1",
+      content: "<p>Foo content1</p>",
+      author: "author1",
+      category: "foo-category",
+      summary: "Foo announcement summary 1"
+    },
+    {
+      title: "Foo announcement 2",
+      link: "https://foo-2.com",
+      published: new Date("2002-02-02T02:02:02Z").toISOString(),
+      updated: new Date("2002-02-02T02:02:02Z").toISOString(),
+      id: "foo-id-2",
+      content: "<p>Foo content2</p>",
+      author: "author2",
+      category: "foo-category",
+      summary: "Foo announcement summary 2"
+    }
+  ];
+
+  const fakeFeedXML = `
+  <feed xmlns="http://www.w3.org/2005/Atom">
+    <generator uri="https://jekyllrb.com/" version="3.10.0">Jekyll</generator>
+    <link href="https://helioviewer-project.github.io/feed.xml" rel="self" type="application/atom+xml"/>
+    <link href="https://helioviewer-project.github.io/" rel="alternate" type="text/html"/>
+    <updated>${new Date().toISOString()}</updated>
+    <id>https://helioviewer-project.github.io/feed.xml</id>
+    <title type="html">Helioviewer Project1</title>
+    <subtitle>Visualization of solar and heliospheric data</subtitle>
+    ${fakeNews
+      .map(
+        (fakenew) => `
+      <entry>
+        <title type="html">${fakenew.title}</title>
+        <link href="${fakenew.link}" rel="alternate" type="text/html" title="${fakenew.title}"/>
+        <published>${fakenew.published}</published>
+        <updated>${fakenew.updated}</updated>
+        <id>${fakenew.id}</id>
+        <content type="html"><![CDATA[ ${fakenew.content} ]]></content>
+        <author><name>${fakenew.author}</name></author>
+        <category term="${fakenew.category}"/>
+        <summary type="html"><![CDATA[ ${fakenew.summary} ]]></summary>
+      </entry>
+    `
+      )
+      .join("")}
+  </feed>`;
+
+  await page.route(`**/*action=getNewsFeed`, async (route) => {
+    // Fetch original response.
+    const response = await route.fetch();
+
+    await route.fulfill({
+      contentType: "text/xml",
+      body: fakeFeedXML
+    });
+  });
+
+  // 1. LOAD HV
+  await hv.Load();
+  await hv.CloseAllNotifications();
+
+  // 2. CLICK NEWS BUTTON TO SHOW NEWS
+  await hv.toggleNewsAndAnnouncements();
+
+  // 3. ASSERT TEXT FROM FAKE NEWS SHOULD BE VISIBLE
+  await expect(page.getByText("Foo announcement 1")).toBeVisible();
+  await expect(page.getByText("2001-01-01 01:01:01.000Z UTC")).toBeVisible();
+  await expect(page.getByText("Foo announcement summary 1")).toBeVisible();
+  await expect(page.getByText("Foo announcement 2")).toBeVisible();
+  await expect(page.getByText("2002-02-02 02:02:02.000Z UTC")).toBeVisible();
+  await expect(page.getByText("Foo announcement summary 2")).toBeVisible();
+
+  // 4. CLICK NEWS BUTTON TO HIDE NEWS
+  await hv.toggleNewsAndAnnouncements();
+
+  // 5. ASSERT TEXT FROM FAKE NEWS SHOULD BE VISIBLE
+  await expect(page.getByText("Foo announcement 1")).not.toBeVisible();
+  await expect(page.getByText("2001-01-01 01:01:01.000Z UTC")).not.toBeVisible();
+  await expect(page.getByText("Foo announcement summary 1")).not.toBeVisible();
+  await expect(page.getByText("Foo announcement 2")).not.toBeVisible();
+  await expect(page.getByText("2002-02-02 02:02:02.000Z UTC")).not.toBeVisible();
+  await expect(page.getByText("Foo announcement summary 2")).not.toBeVisible();
+});

--- a/tests/desktop/normal/youtube/youtube.spec.ts
+++ b/tests/desktop/normal/youtube/youtube.spec.ts
@@ -68,7 +68,7 @@ test("Recently shared youtube videos should be rendered correctly with correct l
   await hv.CloseAllNotifications();
 
   // 2. CLICK YOUTUBE BUTTON TO SHOW YOUTUBE VIDOS
-  await hv.toggleYoutubeVideos();
+  await hv.toggleYoutubeVideosDrawer();
   await hv.WaitForLoadingComplete();
 
   // Assert youtube drawer is open and correct number of videos visible in drawer
@@ -116,7 +116,7 @@ test("If there is no youtube movies then there should be a friendly message", as
   await hv.CloseAllNotifications();
 
   // 2. CLICK NEWS BUTTON TO SHOW YOUTUBE VIDOS
-  await hv.toggleYoutubeVideos();
+  await hv.toggleYoutubeVideosDrawer();
   await hv.WaitForLoadingComplete();
 
   // 3) Assert no videos in the drawer
@@ -204,7 +204,7 @@ test("Youtube movies around observation date should be rendered correctly", asyn
   await hv.CloseAllNotifications();
 
   // 2. CLICK YOUTUBE BUTTON TO SHOW YOUTUBE VIDOS
-  await hv.toggleYoutubeVideos();
+  await hv.toggleYoutubeVideosDrawer();
 
   // 3 TOGGLE VISIBILITY FOR OBSERVATION DATE SHARED VIDEOS ACCORDION INSIDE DRAWER
   await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
@@ -243,7 +243,7 @@ test("If there is no youtube movies around observation date then there should be
   await hv.CloseAllNotifications();
 
   // 2. CLICK NEWS BUTTON TO SHOW YOUTUBE VIDEOS
-  await hv.toggleYoutubeVideos();
+  await hv.toggleYoutubeVideosDrawer();
 
   // 3.  Toggle visibility for observation date shared videos accordion inside drawer
   await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
@@ -333,7 +333,7 @@ test("Youtube movies around observation date should show markers if the 'show in
   await hv.CloseAllNotifications();
 
   // 2. CLICK YOUTUBE BUTTON TO SHOW YOUTUBE VIDOS
-  await hv.toggleYoutubeVideos();
+  await hv.toggleYoutubeVideosDrawer();
   await hv.WaitForLoadingComplete();
   
   // 3 TOGGLE VISIBILITY FOR OBSERVATION DATE SHARED VIDEOS ACCORDION INSIDE DRAWER
@@ -345,7 +345,7 @@ test("Youtube movies around observation date should show markers if the 'show in
 
   // 5 Assert all markers are visible for the mocked videos
   for (const mov of mockedMoviesData) {
-    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoMarkersNotVisibleWithTitle(`AIA ${mov.id}`);
+    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoMarkersVisibleWithTitle(`AIA ${mov.id}`);
   }
 
   // 6 Check checkbox again for hiding location markers for videos
@@ -378,7 +378,7 @@ test("Youtube observation date videos should be updated with the observation dat
   await hv.OpenImageLayerDrawer();
 
   // 3. Open youtube drawer
-  await hv.toggleYoutubeVideos();
+  await hv.toggleYoutubeVideosDrawer();
   await hv.WaitForLoadingComplete();
 
   // 4. Open observation date videos accordion 

--- a/tests/desktop/normal/youtube/youtube.spec.ts
+++ b/tests/desktop/normal/youtube/youtube.spec.ts
@@ -8,21 +8,21 @@ import { getRandomInt } from "../../../utils/utils";
  * 2 ) Open youtube drawer
  * 3 ) Assert all videos mocked before are visible in viewport with correct links and titles
  */
-test("Recently shared youtube videos should be rendered correctly with correct link and title", async ({ page }, info) => {
-
+test("Recently shared youtube videos should be rendered correctly with correct link and title", async ({
+  page
+}, info) => {
   let hv = new Helioviewer(page, info);
 
-  const mockedMovies     = [];
+  const mockedMovies = [];
   const mockedMoviesData = [];
-  const moviesLength = getRandomInt(1, 40); 
+  const moviesLength = getRandomInt(1, 40);
 
   // Prepare some mock data for the recently shared youtube videos
   for (let i = 0; i < moviesLength; i++) {
-
     const hoursAgo = getRandomInt(1, 100);
 
     const id = Math.random().toString(36).substring(2, 7); // Generate random id
-    const startDate = new Date(Date.now() - (hoursAgo * 3600000)).toISOString(); // n hours ago for startdate
+    const startDate = new Date(Date.now() - hoursAgo * 3600000).toISOString(); // n hours ago for startdate
     const publishedDate = startDate; // same as startdate
     const endDate = new Date().toISOString(); // now
 
@@ -47,15 +47,14 @@ test("Recently shared youtube videos should be rendered correctly with correct l
       width: "1552",
       height: "760",
       startDate: startDate,
-      endDate: endDate,
+      endDate: endDate
     });
 
     // Remember what we have mocked so we can assert them later
     mockedMoviesData.push({
       id: id,
-      hoursAgo : hoursAgo
+      hoursAgo: hoursAgo
     });
-
   }
 
   // 0. Mock API requests
@@ -72,27 +71,25 @@ test("Recently shared youtube videos should be rendered correctly with correct l
   await hv.WaitForLoadingComplete();
 
   // Assert youtube drawer is open and correct number of videos visible in drawer
-  await hv.youtubeDrawer.assertDrawerOpen(); 
+  await hv.youtubeDrawer.assertDrawerOpen();
   await hv.youtubeDrawer.assertYoutubeSharedVideoCount(mockedMoviesData.length);
 
   // Assert all mocked videos are visibile with correct links and title
   for (const mov of mockedMoviesData) {
-
     let title = `${mov.hoursAgo} hours ago`;
-    let daysAgo = Math.floor(mov.hoursAgo/24);
+    let daysAgo = Math.floor(mov.hoursAgo / 24);
 
     if (mov.hoursAgo >= 24) {
-        title = `${daysAgo} day ago`;
-    } 
+      title = `${daysAgo} day ago`;
+    }
 
     if (mov.hoursAgo >= 48) {
-        title = `${daysAgo} days ago`;
-    } 
+      title = `${daysAgo} days ago`;
+    }
 
     await hv.youtubeDrawer.assertYoutubeSharedVideoVisibleWithTitle(mov.id, title);
     await hv.youtubeDrawer.assertYoutubeSharedVideoGoesToLink(mov.id, `http://foo.com/watch?v=${mov.id}`);
   }
-
 });
 
 /**
@@ -103,7 +100,6 @@ test("Recently shared youtube videos should be rendered correctly with correct l
  * 4 ) Assert the visibility of friendly no video message
  */
 test("If there is no youtube movies then there should be a friendly message", async ({ page }, info) => {
-
   let hv = new Helioviewer(page, info);
 
   // 0. Mock API requests for no videos
@@ -122,9 +118,8 @@ test("If there is no youtube movies then there should be a friendly message", as
   // 3) Assert no videos in the drawer
   await hv.youtubeDrawer.assertYoutubeSharedVideoCount(0);
 
-  // 4) Assert no video message is visible 
+  // 4) Assert no video message is visible
   await hv.youtubeDrawer.assertNoYoutubeSharedVideoMessage();
-
 });
 
 /**
@@ -135,20 +130,18 @@ test("If there is no youtube movies then there should be a friendly message", as
  * 4 ) Assert all videos mocked before are visible in viewport with correct links and titles
  */
 test("Youtube movies around observation date should be rendered correctly", async ({ page }, info) => {
-
   let hv = new Helioviewer(page, info);
 
-  const mockedMovies     = [];
+  const mockedMovies = [];
   const mockedMoviesData = [];
-  const moviesLength = getRandomInt(1, 40); 
+  const moviesLength = getRandomInt(1, 40);
 
   // Prepare some mock data for the recently shared youtube videos
   for (let i = 0; i < moviesLength; i++) {
-
     const hoursAgo = getRandomInt(1, 100);
 
     const id = Math.random().toString(36).substring(2, 7); // Generate random id
-    const startDate = new Date(Date.now() - (hoursAgo * 3600000)).toISOString(); // n hours ago
+    const startDate = new Date(Date.now() - hoursAgo * 3600000).toISOString(); // n hours ago
     const publishedDate = startDate; // n hours ago
     const endDate = new Date().toISOString(); // now
 
@@ -176,22 +169,21 @@ test("Youtube movies around observation date should be rendered correctly", asyn
       endDate: endDate,
       roi: {
         top: Math.floor(Math.random() * (600 - 300 + 1)) + 300, // Random between 300 and 600
-        left: Math.floor(Math.random() * (-700 - (-1000) + 1)) + -1000, // Random between -1000 and -700
+        left: Math.floor(Math.random() * (-700 - -1000 + 1)) + -1000, // Random between -1000 and -700
         bottom: Math.floor(Math.random() * (1400 - 1100 + 1)) + 1100, // Random between 1100 and 1400
         right: Math.floor(Math.random() * (700 - 500 + 1)) + 500, // Random between 500 and 700
         imageScale: parseFloat((Math.random() * (1.5 - 1.0) + 1.0).toFixed(5)), // Random between 1.0 and 1.5
         width: Math.floor(Math.random() * (1600 - 1400 + 1)) + 1400, // Random between 1400 and 1600
         height: Math.floor(Math.random() * (750 - 650 + 1)) + 650 // Random between 650 and 750
-      },
+      }
     });
 
     // Remember what we have mocked so we can assert them later
     mockedMoviesData.push({
       id: id,
       startDate: startDate,
-      endDate: endDate,
+      endDate: endDate
     });
-
   }
 
   // 0. Mock API requests
@@ -215,10 +207,15 @@ test("Youtube movies around observation date should be rendered correctly", asyn
 
   // Assert all mocked videos are visibile with correct links and title
   for (const mov of mockedMoviesData) {
-    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoVisibleWithTitle(mov.id, `AIA 131  (${mov.startDate} ${mov.endDate} UTC)`);
-    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoGoesToLink(mov.id, `http://anotherfoo.com/watch?v=${mov.id}`);
+    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoVisibleWithTitle(
+      mov.id,
+      `AIA 131  (${mov.startDate} ${mov.endDate} UTC)`
+    );
+    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoGoesToLink(
+      mov.id,
+      `http://anotherfoo.com/watch?v=${mov.id}`
+    );
   }
-
 });
 
 /**
@@ -229,8 +226,9 @@ test("Youtube movies around observation date should be rendered correctly", asyn
  * 4 ) Assert all no videos should be visible
  * 5 ) Assert the visibility of friendly no video message
  */
-test("If there is no youtube movies around observation date then there should be a friendly message", async ({ page }, info) => {
-
+test("If there is no youtube movies around observation date then there should be a friendly message", async ({
+  page
+}, info) => {
   let hv = new Helioviewer(page, info);
 
   // 0. Mock API requests
@@ -252,7 +250,6 @@ test("If there is no youtube movies around observation date then there should be
 
   // 5.  Assert the visibility of friendly no video message
   await hv.youtubeDrawer.assertNoObservationDateYoutubeSharedVideoMessage();
-
 });
 
 /**
@@ -265,21 +262,21 @@ test("If there is no youtube movies around observation date then there should be
  * 4 ) Uncheck checkbox for showing location markers for videos
  * 5 ) Assert no markers are visible for the mocked videos
  */
-test("Youtube movies around observation date should show markers if the 'show in viewport' checkbox is checked", async ({ page }, info) => {
-
+test("Youtube movies around observation date should show markers if the 'show in viewport' checkbox is checked", async ({
+  page
+}, info) => {
   let hv = new Helioviewer(page, info);
 
-  const mockedMovies     = [];
+  const mockedMovies = [];
   const mockedMoviesData = [];
-  const moviesLength = getRandomInt(1, 40); 
+  const moviesLength = getRandomInt(1, 40);
 
   // Mock some data for shared videos
   for (let i = 0; i < moviesLength; i++) {
-
     const hoursAgo = getRandomInt(1, 100);
 
     const id = Math.random().toString(36).substring(2, 7); // Generate random id
-    const startDate = new Date(Date.now() - (hoursAgo * 3600000)).toISOString(); // n hours ago
+    const startDate = new Date(Date.now() - hoursAgo * 3600000).toISOString(); // n hours ago
     const publishedDate = startDate; // n hours ago
     const endDate = new Date().toISOString(); // now
 
@@ -307,21 +304,20 @@ test("Youtube movies around observation date should show markers if the 'show in
       endDate: endDate,
       roi: {
         top: Math.floor(Math.random() * (600 - 300 + 1)) + 300, // Random between 300 and 600
-        left: Math.floor(Math.random() * (-700 - (-1000) + 1)) + -1000, // Random between -1000 and -700
+        left: Math.floor(Math.random() * (-700 - -1000 + 1)) + -1000, // Random between -1000 and -700
         bottom: Math.floor(Math.random() * (1400 - 1100 + 1)) + 1100, // Random between 1100 and 1400
         right: Math.floor(Math.random() * (700 - 500 + 1)) + 500, // Random between 500 and 700
         imageScale: parseFloat((Math.random() * (1.5 - 1.0) + 1.0).toFixed(5)), // Random between 1.0 and 1.5
         width: Math.floor(Math.random() * (1600 - 1400 + 1)) + 1400, // Random between 1400 and 1600
         height: Math.floor(Math.random() * (750 - 650 + 1)) + 650 // Random between 650 and 750
-      },
+      }
     });
 
     mockedMoviesData.push({
       id: id,
       startDate: startDate,
-      endDate: endDate,
+      endDate: endDate
     });
-
   }
 
   await page.route("*/**/?action=getObservationDateVideos*", async (route) => {
@@ -335,7 +331,7 @@ test("Youtube movies around observation date should show markers if the 'show in
   // 2. CLICK YOUTUBE BUTTON TO SHOW YOUTUBE VIDOS
   await hv.toggleYoutubeVideosDrawer();
   await hv.WaitForLoadingComplete();
-  
+
   // 3 TOGGLE VISIBILITY FOR OBSERVATION DATE SHARED VIDEOS ACCORDION INSIDE DRAWER
   await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
   await hv.WaitForLoadingComplete();
@@ -355,11 +351,10 @@ test("Youtube movies around observation date should show markers if the 'show in
   for (const mov of mockedMoviesData) {
     await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoMarkersNotVisibleWithTitle(`AIA ${mov.id}`);
   }
-
 });
 
 /**
- * Test Steps for checking observation date shared videos are updated when the observation date changes 
+ * Test Steps for checking observation date shared videos are updated when the observation date changes
  * 1) Load hv
  * 2) Open youtube drawer
  * 3) Toggle visibility for observation date shared videos accordion inside drawer
@@ -367,13 +362,12 @@ test("Youtube movies around observation date should show markers if the 'show in
  * 5) Expect a request to be made to fetch new videos for observation date
  */
 test("Youtube observation date videos should be updated with the observation date change ", async ({ page }, info) => {
-
   let hv = new Helioviewer(page, info);
 
   // 1. LOAD HV
   await hv.Load();
   await hv.CloseAllNotifications();
-  
+
   // 2. Open Sidebar to control date
   await hv.OpenImageLayerDrawer();
 
@@ -381,21 +375,22 @@ test("Youtube observation date videos should be updated with the observation dat
   await hv.toggleYoutubeVideosDrawer();
   await hv.WaitForLoadingComplete();
 
-  // 4. Open observation date videos accordion 
+  // 4. Open observation date videos accordion
   await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
- 
+
   // Calculate observation date to one week before the current date
   const initialDate = await hv.GetLoadedDate();
   const oneWeekOfSeconds = 604800;
-  const oneWeekBeforeDate = new Date(initialDate.getTime() - oneWeekOfSeconds * 1000)
-  const oneWeekBeforeDateURLEncoded = encodeURIComponent(oneWeekBeforeDate.toISOString().slice(0,19));
+  const oneWeekBeforeDate = new Date(initialDate.getTime() - oneWeekOfSeconds * 1000);
+  const oneWeekBeforeDateURLEncoded = encodeURIComponent(oneWeekBeforeDate.toISOString().slice(0, 19));
 
   // 5. Expect a request to be made to fetch new youtube videos around new observation date
-  const fetchNewObservationDateYoutubeRequestPromise = page.waitForRequest(new RegExp(`\\?action=getObservationDateVideos\\&date=${oneWeekBeforeDateURLEncoded}`));
+  const fetchNewObservationDateYoutubeRequestPromise = page.waitForRequest(
+    new RegExp(`\\?action=getObservationDateVideos\\&date=${oneWeekBeforeDateURLEncoded}`)
+  );
 
-  // 6. Set the observation date one week back , 
+  // 6. Set the observation date one week back ,
   await hv.JumpBackwardsDateWithSelection(oneWeekOfSeconds); // Go one week backwards
 
   await fetchNewObservationDateYoutubeRequestPromise;
-
 });

--- a/tests/desktop/normal/youtube/youtube.spec.ts
+++ b/tests/desktop/normal/youtube/youtube.spec.ts
@@ -1,0 +1,401 @@
+import { test, expect } from "@playwright/test";
+import { Helioviewer } from "../../../page_objects/helioviewer";
+import { getRandomInt } from "../../../utils/utils";
+
+/**
+ * Test Steps for checking recently shared videos are rendered correctly
+ * 1 ) Mock some data for recently shared youtube videos:
+ * 2 ) Open youtube drawer
+ * 3 ) Assert all videos mocked before are visible in viewport with correct links and titles
+ */
+test("Recently shared youtube videos should be rendered correctly with correct link and title", async ({ page }, info) => {
+
+  let hv = new Helioviewer(page, info);
+
+  const mockedMovies     = [];
+  const mockedMoviesData = [];
+  const moviesLength = getRandomInt(1, 40); 
+
+  // Prepare some mock data for the recently shared youtube videos
+  for (let i = 0; i < moviesLength; i++) {
+
+    const hoursAgo = getRandomInt(1, 100);
+
+    const id = Math.random().toString(36).substring(2, 7); // Generate random id
+    const startDate = new Date(Date.now() - (hoursAgo * 3600000)).toISOString(); // n hours ago for startdate
+    const publishedDate = startDate; // same as startdate
+    const endDate = new Date().toISOString(); // now
+
+    mockedMovies.push({
+      id: id,
+      url: `http://foo.com/watch?v=${id}`,
+      thumbnails: {
+        icon: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        small: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        medium: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        large: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        full: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png"
+      },
+      published: publishedDate,
+      title: `AIA 131 (${startDate} - ${endDate} UTC)`,
+      description: `This movie was mocked by playwright tests`,
+      keywords: "SDO,AIA,131,1",
+      imageScale: "0.915297",
+      dataSourceString: `[SDO,AIA,131,1,86,0,60,1,2024-01-10T18:46:22.000Z]`,
+      eventSourceString: "",
+      movieLength: (Math.random() * 10).toFixed(5),
+      width: "1552",
+      height: "760",
+      startDate: startDate,
+      endDate: endDate,
+    });
+
+    // Remember what we have mocked so we can assert them later
+    mockedMoviesData.push({
+      id: id,
+      hoursAgo : hoursAgo
+    });
+
+  }
+
+  // 0. Mock API requests
+  await page.route("*/**/?action=getUserVideos*", async (route) => {
+    await route.fulfill({ json: mockedMovies });
+  });
+
+  // 1. LOAD HV
+  await hv.Load();
+  await hv.CloseAllNotifications();
+
+  // 2. CLICK YOUTUBE BUTTON TO SHOW YOUTUBE VIDOS
+  await hv.toggleYoutubeVideos();
+  await hv.WaitForLoadingComplete();
+
+  // Assert youtube drawer is open and correct number of videos visible in drawer
+  await hv.youtubeDrawer.assertDrawerOpen(); 
+  await hv.youtubeDrawer.assertYoutubeSharedVideoCount(mockedMoviesData.length);
+
+  // Assert all mocked videos are visibile with correct links and title
+  for (const mov of mockedMoviesData) {
+
+    let title = `${mov.hoursAgo} hours ago`;
+    let daysAgo = Math.floor(mov.hoursAgo/24);
+
+    if (mov.hoursAgo >= 24) {
+        title = `${daysAgo} day ago`;
+    } 
+
+    if (mov.hoursAgo >= 48) {
+        title = `${daysAgo} days ago`;
+    } 
+
+    await hv.youtubeDrawer.assertYoutubeSharedVideoVisibleWithTitle(mov.id, title);
+    await hv.youtubeDrawer.assertYoutubeSharedVideoGoesToLink(mov.id, `http://foo.com/watch?v=${mov.id}`);
+  }
+
+});
+
+/**
+ * Test Steps for checking visibility of a friendly message when there is no recently shared videos.
+ * 1 ) Mock empty data response for recently shared youtube videos:
+ * 2 ) Open youtube drawer
+ * 3 ) Assert all no videos should be visible
+ * 4 ) Assert the visibility of friendly no video message
+ */
+test("If there is no youtube movies then there should be a friendly message", async ({ page }, info) => {
+
+  let hv = new Helioviewer(page, info);
+
+  // 0. Mock API requests for no videos
+  await page.route("*/**/?action=getUserVideos*", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+
+  // 1. LOAD HV
+  await hv.Load();
+  await hv.CloseAllNotifications();
+
+  // 2. CLICK NEWS BUTTON TO SHOW YOUTUBE VIDOS
+  await hv.toggleYoutubeVideos();
+  await hv.WaitForLoadingComplete();
+
+  // 3) Assert no videos in the drawer
+  await hv.youtubeDrawer.assertYoutubeSharedVideoCount(0);
+
+  // 4) Assert no video message is visible 
+  await hv.youtubeDrawer.assertNoYoutubeSharedVideoMessage();
+
+});
+
+/**
+ * Test Steps for checking observation date shared videos are rendered correctly
+ * 1 ) Mock some data for observation date shared youtube videos:
+ * 2 ) Open youtube drawer
+ * 3 ) Toggle visibility for observation date shared videos accordion inside drawer
+ * 4 ) Assert all videos mocked before are visible in viewport with correct links and titles
+ */
+test("Youtube movies around observation date should be rendered correctly", async ({ page }, info) => {
+
+  let hv = new Helioviewer(page, info);
+
+  const mockedMovies     = [];
+  const mockedMoviesData = [];
+  const moviesLength = getRandomInt(1, 40); 
+
+  // Prepare some mock data for the recently shared youtube videos
+  for (let i = 0; i < moviesLength; i++) {
+
+    const hoursAgo = getRandomInt(1, 100);
+
+    const id = Math.random().toString(36).substring(2, 7); // Generate random id
+    const startDate = new Date(Date.now() - (hoursAgo * 3600000)).toISOString(); // n hours ago
+    const publishedDate = startDate; // n hours ago
+    const endDate = new Date().toISOString(); // now
+
+    mockedMovies.push({
+      id: id,
+      url: `http://anotherfoo.com/watch?v=${id}`,
+      thumbnails: {
+        icon: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        small: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        medium: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        large: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        full: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png"
+      },
+      published: publishedDate,
+      title: `AIA 131 (${startDate} - ${endDate} UTC)`,
+      description: `This movie was mocked by playwright tests`,
+      keywords: "SDO,AIA,131,1",
+      imageScale: "0.915297",
+      dataSourceString: `[SDO,AIA,131,1,86,0,60,1,2024-01-10T18:46:22.000Z]`,
+      eventSourceString: "",
+      movieLength: (Math.random() * 10).toFixed(5),
+      width: "1552",
+      height: "760",
+      startDate: startDate,
+      endDate: endDate,
+      roi: {
+        top: Math.floor(Math.random() * (600 - 300 + 1)) + 300, // Random between 300 and 600
+        left: Math.floor(Math.random() * (-700 - (-1000) + 1)) + -1000, // Random between -1000 and -700
+        bottom: Math.floor(Math.random() * (1400 - 1100 + 1)) + 1100, // Random between 1100 and 1400
+        right: Math.floor(Math.random() * (700 - 500 + 1)) + 500, // Random between 500 and 700
+        imageScale: parseFloat((Math.random() * (1.5 - 1.0) + 1.0).toFixed(5)), // Random between 1.0 and 1.5
+        width: Math.floor(Math.random() * (1600 - 1400 + 1)) + 1400, // Random between 1400 and 1600
+        height: Math.floor(Math.random() * (750 - 650 + 1)) + 650 // Random between 650 and 750
+      },
+    });
+
+    // Remember what we have mocked so we can assert them later
+    mockedMoviesData.push({
+      id: id,
+      startDate: startDate,
+      endDate: endDate,
+    });
+
+  }
+
+  // 0. Mock API requests
+  await page.route("*/**/?action=getObservationDateVideos*", async (route) => {
+    await route.fulfill({ json: mockedMovies });
+  });
+
+  // 1. LOAD HV
+  await hv.Load();
+  await hv.CloseAllNotifications();
+
+  // 2. CLICK YOUTUBE BUTTON TO SHOW YOUTUBE VIDOS
+  await hv.toggleYoutubeVideos();
+
+  // 3 TOGGLE VISIBILITY FOR OBSERVATION DATE SHARED VIDEOS ACCORDION INSIDE DRAWER
+  await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
+  await hv.WaitForLoadingComplete();
+
+  // Assert correct number of videos visible in drawer
+  await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoCount(mockedMoviesData.length);
+
+  // Assert all mocked videos are visibile with correct links and title
+  for (const mov of mockedMoviesData) {
+    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoVisibleWithTitle(mov.id, `AIA 131  (${mov.startDate} ${mov.endDate} UTC)`);
+    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoGoesToLink(mov.id, `http://anotherfoo.com/watch?v=${mov.id}`);
+  }
+
+});
+
+/**
+ * Test Steps for checking visibility of a friendly message when there is no observation date youtube shared videos.
+ * 1 ) Mock empty data response for observation date shared youtube videos:
+ * 2 ) Open youtube drawer
+ * 3 ) Toggle visibility for observation date shared videos accordion inside drawer
+ * 4 ) Assert all no videos should be visible
+ * 5 ) Assert the visibility of friendly no video message
+ */
+test("If there is no youtube movies around observation date then there should be a friendly message", async ({ page }, info) => {
+
+  let hv = new Helioviewer(page, info);
+
+  // 0. Mock API requests
+  await page.route("*/**/?action=getObservationDateVideos*", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+
+  // 1. LOAD HV
+  await hv.Load();
+  await hv.CloseAllNotifications();
+
+  // 2. CLICK NEWS BUTTON TO SHOW YOUTUBE VIDEOS
+  await hv.toggleYoutubeVideos();
+
+  // 3.  Toggle visibility for observation date shared videos accordion inside drawer
+  await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
+  // 4.  Assert all no videos should be visible
+  await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoCount(0);
+
+  // 5.  Assert the visibility of friendly no video message
+  await hv.youtubeDrawer.assertNoObservationDateYoutubeSharedVideoMessage();
+
+});
+
+/**
+ * Test Steps for checking observation date shared video location markers visibility can be controlled from ui checkbox
+ * 1 ) Mock some data for observation date shared youtube videos:
+ * 2 ) Open youtube drawer
+ * 3 ) Toggle visibility for observation date shared videos accordion inside drawer
+ * 4 ) Check checkbox for showing location markers for videos
+ * 5 ) Assert all markers are visible for the mocked videos
+ * 4 ) Uncheck checkbox for showing location markers for videos
+ * 5 ) Assert no markers are visible for the mocked videos
+ */
+test("Youtube movies around observation date should show markers if the 'show in viewport' checkbox is checked", async ({ page }, info) => {
+
+  let hv = new Helioviewer(page, info);
+
+  const mockedMovies     = [];
+  const mockedMoviesData = [];
+  const moviesLength = getRandomInt(1, 40); 
+
+  // Mock some data for shared videos
+  for (let i = 0; i < moviesLength; i++) {
+
+    const hoursAgo = getRandomInt(1, 100);
+
+    const id = Math.random().toString(36).substring(2, 7); // Generate random id
+    const startDate = new Date(Date.now() - (hoursAgo * 3600000)).toISOString(); // n hours ago
+    const publishedDate = startDate; // n hours ago
+    const endDate = new Date().toISOString(); // now
+
+    mockedMovies.push({
+      id: id,
+      url: `http://anotherfoo.com/watch?v=${id}`,
+      thumbnails: {
+        icon: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        small: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        medium: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        large: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png",
+        full: "https://helioviewer.org/resources/images/viewyoutube_icon_transp.png"
+      },
+      published: publishedDate,
+      title: `AIA ${id} (${startDate} - ${endDate} UTC)`,
+      description: `This movie was mocked by playwright tests`,
+      keywords: "SDO,AIA,131,1",
+      imageScale: "0.915297",
+      dataSourceString: `[SDO,AIA,131,1,86,0,60,1,2024-01-10T18:46:22.000Z]`,
+      eventSourceString: "",
+      movieLength: (Math.random() * 10).toFixed(5),
+      width: "1552",
+      height: "760",
+      startDate: startDate,
+      endDate: endDate,
+      roi: {
+        top: Math.floor(Math.random() * (600 - 300 + 1)) + 300, // Random between 300 and 600
+        left: Math.floor(Math.random() * (-700 - (-1000) + 1)) + -1000, // Random between -1000 and -700
+        bottom: Math.floor(Math.random() * (1400 - 1100 + 1)) + 1100, // Random between 1100 and 1400
+        right: Math.floor(Math.random() * (700 - 500 + 1)) + 500, // Random between 500 and 700
+        imageScale: parseFloat((Math.random() * (1.5 - 1.0) + 1.0).toFixed(5)), // Random between 1.0 and 1.5
+        width: Math.floor(Math.random() * (1600 - 1400 + 1)) + 1400, // Random between 1400 and 1600
+        height: Math.floor(Math.random() * (750 - 650 + 1)) + 650 // Random between 650 and 750
+      },
+    });
+
+    mockedMoviesData.push({
+      id: id,
+      startDate: startDate,
+      endDate: endDate,
+    });
+
+  }
+
+  await page.route("*/**/?action=getObservationDateVideos*", async (route) => {
+    await route.fulfill({ json: mockedMovies });
+  });
+
+  // 1. LOAD HV
+  await hv.Load();
+  await hv.CloseAllNotifications();
+
+  // 2. CLICK YOUTUBE BUTTON TO SHOW YOUTUBE VIDOS
+  await hv.toggleYoutubeVideos();
+  await hv.WaitForLoadingComplete();
+  
+  // 3 TOGGLE VISIBILITY FOR OBSERVATION DATE SHARED VIDEOS ACCORDION INSIDE DRAWER
+  await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
+  await hv.WaitForLoadingComplete();
+
+  // 4 Check checkbox for showing location markers for videos
+  await hv.youtubeDrawer.showSunLocationMarkersForForObservationDateVideos();
+
+  // 5 Assert all markers are visible for the mocked videos
+  for (const mov of mockedMoviesData) {
+    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoMarkersNotVisibleWithTitle(`AIA ${mov.id}`);
+  }
+
+  // 6 Check checkbox again for hiding location markers for videos
+  await hv.youtubeDrawer.hideSunLocationMarkersForForObservationDateVideos();
+
+  // 7 Assert all markers are NOT visible for the mocked videos
+  for (const mov of mockedMoviesData) {
+    await hv.youtubeDrawer.assertObservationDateYoutubeSharedVideoMarkersNotVisibleWithTitle(`AIA ${mov.id}`);
+  }
+
+});
+
+/**
+ * Test Steps for checking observation date shared videos are updated when the observation date changes 
+ * 1) Load hv
+ * 2) Open youtube drawer
+ * 3) Toggle visibility for observation date shared videos accordion inside drawer
+ * 4) Set observation date to one week back of current datetime
+ * 5) Expect a request to be made to fetch new videos for observation date
+ */
+test("Youtube observation date videos should be updated with the observation date change ", async ({ page }, info) => {
+
+  let hv = new Helioviewer(page, info);
+
+  // 1. LOAD HV
+  await hv.Load();
+  await hv.CloseAllNotifications();
+  
+  // 2. Open Sidebar to control date
+  await hv.OpenImageLayerDrawer();
+
+  // 3. Open youtube drawer
+  await hv.toggleYoutubeVideos();
+  await hv.WaitForLoadingComplete();
+
+  // 4. Open observation date videos accordion 
+  await hv.youtubeDrawer.toggleObservationDateYoutubeSharedAccordion();
+ 
+  // Calculate observation date to one week before the current date
+  const initialDate = await hv.GetLoadedDate();
+  const oneWeekOfSeconds = 604800;
+  const oneWeekBeforeDate = new Date(initialDate.getTime() - oneWeekOfSeconds * 1000)
+  const oneWeekBeforeDateURLEncoded = encodeURIComponent(oneWeekBeforeDate.toISOString().slice(0,19));
+
+  // 5. Expect a request to be made to fetch new youtube videos around new observation date
+  const fetchNewObservationDateYoutubeRequestPromise = page.waitForRequest(new RegExp(`\\?action=getObservationDateVideos\\&date=${oneWeekBeforeDateURLEncoded}`));
+
+  // 6. Set the observation date one week back , 
+  await hv.JumpBackwardsDateWithSelection(oneWeekOfSeconds); // Go one week backwards
+
+  await fetchNewObservationDateYoutubeRequestPromise;
+
+});

--- a/tests/page_objects/helioviewer.ts
+++ b/tests/page_objects/helioviewer.ts
@@ -493,6 +493,14 @@ class Helioviewer implements DesktopInterface {
   async centerViewport(): Promise<void> {
     await this.page.locator("#center-button").click();
   }
+
+  /**
+   * Click news button in top controls to see news button or hide it
+   * @returns {Promise<void>}
+   */
+  async toggleNewsAndAnnouncements(): Promise<void> {
+    await this.page.locator("#news-button").click();
+  }
 }
 
 export { Helioviewer };

--- a/tests/page_objects/helioviewer.ts
+++ b/tests/page_objects/helioviewer.ts
@@ -9,6 +9,7 @@ import { Movie } from "./movie";
 import { URLShare } from "./urlshare";
 import { EventTree } from "./event_tree";
 import { VSODrawer } from "./vso_drawer";
+import { YoutubeDrawer } from "./youtube_drawer";
 import { ScaleIndicator } from "./scale_indicator";
 import * as fs from "fs";
 import { DesktopInterface } from "./helioviewer_interface";
@@ -42,6 +43,7 @@ class Helioviewer implements DesktopInterface {
     this.vso_drawer = new VSODrawer(this.page);
     this.scale_indicator = new ScaleIndicator(this.page);
     this.sidebar = this.page.locator("#hv-drawer-left");
+    this.youtubeDrawer = new YoutubeDrawer(this.page);
   }
 
   /**
@@ -500,6 +502,14 @@ class Helioviewer implements DesktopInterface {
    */
   async toggleNewsAndAnnouncements(): Promise<void> {
     await this.page.locator("#news-button").click();
+  }
+
+  /**
+   * Click youtube button in top controls to see the shared youtube videos
+   * @returns {Promise<void>}
+   */
+  async toggleYoutubeVideos(): Promise<void> {
+    await this.page.locator("#youtube-button").click();
   }
 }
 

--- a/tests/page_objects/helioviewer.ts
+++ b/tests/page_objects/helioviewer.ts
@@ -33,6 +33,7 @@ class Helioviewer implements DesktopInterface {
   urlshare: URLShare;
   vso_drawer: VSODrawer;
   scale_indicator: ScaleIndicator;
+  youtubeDrawer: YoutubeDrawer;
 
   constructor(page: Page, info: TestInfo | null = null) {
     this.page = page;

--- a/tests/page_objects/helioviewer.ts
+++ b/tests/page_objects/helioviewer.ts
@@ -516,7 +516,7 @@ class Helioviewer implements DesktopInterface {
    * Click youtube button in top controls to see the shared youtube videos
    * @returns {Promise<void>}
    */
-  async toggleYoutubeVideos(): Promise<void> {
+  async toggleYoutubeVideosDrawer(): Promise<void> {
     await this.page.locator("#youtube-button").click();
   }
 }

--- a/tests/page_objects/youtube_drawer.ts
+++ b/tests/page_objects/youtube_drawer.ts
@@ -13,8 +13,8 @@ class YoutubeDrawer {
   constructor(page: Page) {
     this.page = page;
     this.drawer = this.page.locator("#hv-drawer-youtube");
-    this.accordionYoutube = this.drawer.locator('#accordion-youtube');
-    this.accordionObservationDate = this.drawer.locator('#accordion-youtube-current');
+    this.accordionYoutube = this.drawer.locator("#accordion-youtube");
+    this.accordionObservationDate = this.drawer.locator("#accordion-youtube-current");
   }
 
   /**
@@ -39,7 +39,7 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async assertYoutubeSharedVideoCount(count: number): Promise<void> {
-    await expect(this.accordionYoutube.locator('img').locator('visible=true')).toHaveCount(count);
+    await expect(this.accordionYoutube.locator("img").locator("visible=true")).toHaveCount(count);
   }
 
   /**
@@ -48,7 +48,7 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async assertObservationDateYoutubeSharedVideoCount(count: number): Promise<void> {
-    await expect(this.accordionObservationDate.locator('img').locator('visible=true')).toHaveCount(count);
+    await expect(this.accordionObservationDate.locator("img").locator("visible=true")).toHaveCount(count);
   }
 
   /**
@@ -59,7 +59,7 @@ class YoutubeDrawer {
    */
   async assertYoutubeSharedVideoVisibleWithTitle(id: string, title: string): Promise<void> {
     await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`)).toBeVisible();
-    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`).locator('xpath=..')).toHaveText(title);
+    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`).locator("xpath=..")).toHaveText(title);
   }
 
   /**
@@ -70,7 +70,9 @@ class YoutubeDrawer {
    */
   async assertObservationDateYoutubeSharedVideoVisibleWithTitle(id: string, title: string): Promise<void> {
     await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`)).toBeVisible();
-    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`).locator('xpath=..')).toHaveText(title);
+    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`).locator("xpath=..")).toHaveText(
+      title
+    );
   }
 
   /**
@@ -81,7 +83,7 @@ class YoutubeDrawer {
    */
   async assertYoutubeSharedVideoGoesToLink(id: string, link: string): Promise<void> {
     await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`)).toBeVisible();
-    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`)).toHaveAttribute('href', link);
+    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`)).toHaveAttribute("href", link);
   }
 
   /**
@@ -92,7 +94,7 @@ class YoutubeDrawer {
    */
   async assertObservationDateYoutubeSharedVideoGoesToLink(id: string, link: string): Promise<void> {
     await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`)).toBeVisible();
-    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`)).toHaveAttribute('href', link);
+    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`)).toHaveAttribute("href", link);
   }
 
   /**
@@ -100,7 +102,7 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async assertNoYoutubeSharedVideoMessage(): Promise<void> {
-    await expect(this.accordionYoutube.locator('#user-video-gallery')).toHaveText("No shared movies found.");
+    await expect(this.accordionYoutube.locator("#user-video-gallery")).toHaveText("No shared movies found.");
   }
 
   /**
@@ -108,7 +110,9 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async assertNoObservationDateYoutubeSharedVideoMessage(): Promise<void> {
-    await expect(this.accordionObservationDate.locator('#user-video-gallery-current')).toContainText("No movies found around the observation date.");
+    await expect(this.accordionObservationDate.locator("#user-video-gallery-current")).toContainText(
+      "No movies found around the observation date."
+    );
   }
 
   /**
@@ -116,7 +120,7 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async toggleYoutubeSharedAccordion(): Promise<void> {
-    await this.accordionYoutube.locator('.header').click();
+    await this.accordionYoutube.locator(".header").click();
   }
 
   /**
@@ -124,23 +128,23 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async toggleObservationDateYoutubeSharedAccordion(): Promise<void> {
-    await this.accordionObservationDate.locator('.header').click();
+    await this.accordionObservationDate.locator(".header").click();
   }
 
   /**
-   * Enable visibility of video markers indicating locations of the recorded video 
+   * Enable visibility of video markers indicating locations of the recorded video
    * @returns {Promise<void>}
    */
   async showSunLocationMarkersForForObservationDateVideos(): Promise<void> {
-    await this.accordionObservationDate.locator('#movies-show-in-viewport').check();
+    await this.accordionObservationDate.locator("#movies-show-in-viewport").check();
   }
 
   /**
-   * Disable visibility of video markers indicating locations of the recorded video 
+   * Disable visibility of video markers indicating locations of the recorded video
    * @returns {Promise<void>}
    */
   async hideSunLocationMarkersForForObservationDateVideos(): Promise<void> {
-    await this.accordionObservationDate.locator('#movies-show-in-viewport').uncheck();
+    await this.accordionObservationDate.locator("#movies-show-in-viewport").uncheck();
   }
 
   /**
@@ -149,7 +153,7 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async assertObservationDateYoutubeSharedVideoMarkersVisibleWithTitle(markerTitle: string): Promise<void> {
-    await expect(this.page.getByRole('link', { name: markerTitle})).toBeVisible();
+    await expect(this.page.getByRole("link", { name: markerTitle })).toBeVisible();
   }
 
   /**
@@ -158,7 +162,7 @@ class YoutubeDrawer {
    * @returns {Promise<void>}
    */
   async assertObservationDateYoutubeSharedVideoMarkersNotVisibleWithTitle(markerTitle: string): Promise<void> {
-    await expect(this.page.getByRole('link', { name: markerTitle})).not.toBeVisible();
+    await expect(this.page.getByRole("link", { name: markerTitle })).not.toBeVisible();
   }
 }
 

--- a/tests/page_objects/youtube_drawer.ts
+++ b/tests/page_objects/youtube_drawer.ts
@@ -1,0 +1,147 @@
+import { Page, Locator, expect } from "@playwright/test";
+
+/**
+ * Interface for interacting with elements related to youtube shared videos drawer drawer
+ */
+class YoutubeDrawer {
+  /** Playwright page instance */
+  private page: Page;
+  private drawer: Locator;
+  private accordionYoutube: Locator;
+  private accordionObservationDate: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.drawer = this.page.locator("#hv-drawer-youtube");
+    this.accordionYoutube = this.drawer.locator('#accordion-youtube');
+    this.accordionObservationDate = this.drawer.locator('#accordion-youtube-current');
+  }
+
+  /**
+   * Assert drawer is open
+   * @returns {Promise<void>}
+   */
+  async assertDrawerOpen(): Promise<void> {
+    await expect(this.drawer).toBeVisible();
+  }
+
+  /**
+   * Assert drawer is closed
+   * @returns {Promise<void>}
+   */
+  async assertDrawerClose(): Promise<void> {
+    await expect(this.drawer).not.toBeVisible();
+  }
+
+  /**
+   * Assert video count of youtube shared videos
+   * @param {number} count expected video number
+   * @returns {Promise<void>}
+   */
+  async assertYoutubeSharedVideoCount(count: number): Promise<void> {
+    await expect(this.accordionYoutube.locator('img').locator('visible=true')).toHaveCount(count);
+  }
+
+  /**
+   * Assert video count of observation date youtube shared videos
+   * @param {number} count expected video number
+   * @returns {Promise<void>}
+   */
+  async assertObservationDateYoutubeSharedVideoCount(count: number): Promise<void> {
+    await expect(this.accordionObservationDate.locator('img').locator('visible=true')).toHaveCount(count);
+  }
+
+  /**
+   * Assert visibility of video and its title for shared youtube videos
+   * @param {id} string video youtube id
+   * @param {title} string title for the video
+   * @returns {Promise<void>}
+   */
+  async assertYoutubeSharedVideoVisibleWithTitle(id: string, title: string): Promise<void> {
+    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`)).toBeVisible();
+    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`).locator('xpath=..')).toHaveText(title);
+  }
+
+  /**
+   * Assert visibility of video and its title for observation date shared youtube videos
+   * @param {id} string video youtube id
+   * @param {title} string title for the video
+   * @returns {Promise<void>}
+   */
+  async assertObservationDateYoutubeSharedVideoVisibleWithTitle(id: string, title: string): Promise<void> {
+    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`)).toBeVisible();
+    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`).locator('xpath=..')).toHaveText(title);
+  }
+
+  /**
+   * Assert the video link for given shared youtube video
+   * @param {id} string video youtube id
+   * @param {link} string URL for the video
+   * @returns {Promise<void>}
+   */
+  async assertYoutubeSharedVideoGoesToLink(id: string, link: string): Promise<void> {
+    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`)).toBeVisible();
+    await expect(this.accordionYoutube.locator(`#youtube-movie-current-${id}`)).toHaveAttribute('href', link);
+  }
+
+  /**
+   * Assert the video link for given shared observation date youtube video
+   * @param {id} string video youtube id
+   * @param {link} string URL for the video
+   * @returns {Promise<void>}
+   */
+  async assertObservationDateYoutubeSharedVideoGoesToLink(id: string, link: string): Promise<void> {
+    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`)).toBeVisible();
+    await expect(this.accordionObservationDate.locator(`#youtube-movie-current-${id}`)).toHaveAttribute('href', link);
+  }
+
+  /**
+   * Assert visibility of helpful message when there is no youtube shared video
+   * @returns {Promise<void>}
+   */
+  async assertNoYoutubeSharedVideoMessage(): Promise<void> {
+    await expect(this.accordionYoutube.locator('#user-video-gallery')).toHaveText("No shared movies found.");
+  }
+
+  /**
+   * Assert visibility of helpful message when there is no observation date youtube shared video
+   * @returns {Promise<void>}
+   */
+  async assertNoObservationDateYoutubeSharedVideoMessage(): Promise<void> {
+    await expect(this.accordionObservationDate.locator('#user-video-gallery-current')).toContainText("No movies found around the observation date.");
+  }
+
+  /**
+   * Toggle visibility of youtube shared videos accordion inside the youtube drawer
+   * @returns {Promise<void>}
+   */
+  async toggleYoutubeSharedAccordion(): Promise<void> {
+    await this.accordionYoutube.locator('.header').click();
+  }
+
+  /**
+   * Toggle visibility of youtube observation date shared videos accordion inside the youtube drawer
+   * @returns {Promise<void>}
+   */
+  async toggleObservationDateYoutubeSharedAccordion(): Promise<void> {
+    await this.accordionObservationDate.locator('.header').click();
+  }
+
+  /**
+   * Enable visibility of video markers indicating locations of the recorded video 
+   * @returns {Promise<void>}
+   */
+  async showSunLocationMarkersForForObservationDateVideos(): Promise<void> {
+    await this.accordionObservationDate.locator('#movies-show-in-viewport').check();
+  }
+
+  /**
+   * Disable visibility of video markers indicating locations of the recorded video 
+   * @returns {Promise<void>}
+   */
+  async hideSunLocationMarkersForForObservationDateVideos(): Promise<void> {
+    await this.accordionObservationDate.locator('#movies-show-in-viewport').uncheck();
+  }
+}
+
+export { YoutubeDrawer };

--- a/tests/page_objects/youtube_drawer.ts
+++ b/tests/page_objects/youtube_drawer.ts
@@ -53,8 +53,8 @@ class YoutubeDrawer {
 
   /**
    * Assert visibility of video and its title for shared youtube videos
-   * @param {id} string video youtube id
-   * @param {title} string title for the video
+   * @param {string} id of video
+   * @param {string} title for the video
    * @returns {Promise<void>}
    */
   async assertYoutubeSharedVideoVisibleWithTitle(id: string, title: string): Promise<void> {
@@ -64,8 +64,8 @@ class YoutubeDrawer {
 
   /**
    * Assert visibility of video and its title for observation date shared youtube videos
-   * @param {id} string video youtube id
-   * @param {title} string title for the video
+   * @param {string} id of video
+   * @param {string} title for the video
    * @returns {Promise<void>}
    */
   async assertObservationDateYoutubeSharedVideoVisibleWithTitle(id: string, title: string): Promise<void> {
@@ -75,8 +75,8 @@ class YoutubeDrawer {
 
   /**
    * Assert the video link for given shared youtube video
-   * @param {id} string video youtube id
-   * @param {link} string URL for the video
+   * @param {string} id of video
+   * @param {string} link for the video
    * @returns {Promise<void>}
    */
   async assertYoutubeSharedVideoGoesToLink(id: string, link: string): Promise<void> {
@@ -86,8 +86,8 @@ class YoutubeDrawer {
 
   /**
    * Assert the video link for given shared observation date youtube video
-   * @param {id} string video youtube id
-   * @param {link} string URL for the video
+   * @param {string} id of video
+   * @param {string} link for the video
    * @returns {Promise<void>}
    */
   async assertObservationDateYoutubeSharedVideoGoesToLink(id: string, link: string): Promise<void> {
@@ -141,6 +141,24 @@ class YoutubeDrawer {
    */
   async hideSunLocationMarkersForForObservationDateVideos(): Promise<void> {
     await this.accordionObservationDate.locator('#movies-show-in-viewport').uncheck();
+  }
+
+  /**
+   * Assert visibility for observation date  youtube video markers are visible
+   * @param {string} markerTitle of the marker
+   * @returns {Promise<void>}
+   */
+  async assertObservationDateYoutubeSharedVideoMarkersVisibleWithTitle(markerTitle: string): Promise<void> {
+    await expect(this.page.getByRole('link', { name: markerTitle})).toBeVisible();
+  }
+
+  /**
+   * Assert no-visibility for observation date  youtube video markers are visible
+   * @param {string} markerTitle of the marker
+   * @returns {Promise<void>}
+   */
+  async assertObservationDateYoutubeSharedVideoMarkersNotVisibleWithTitle(markerTitle: string): Promise<void> {
+    await expect(this.page.getByRole('link', { name: markerTitle})).not.toBeVisible();
   }
 }
 

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -1,0 +1,19 @@
+
+/**
+ * Generates a random integer within a specified range (inclusive).
+ *
+ * @param {number} min - The minimum integer value that can be returned.
+ * @param {number} max - The maximum integer value that can be returned.
+ * @returns {number} A random integer between the specified min and max values, inclusive.
+ */
+function getRandomInt(min: number, max: number): number {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+
+
+
+
+export { getRandomInt };

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -1,4 +1,3 @@
-
 /**
  * Generates a random integer within a specified range (inclusive).
  *
@@ -11,9 +10,5 @@ function getRandomInt(min: number, max: number): number {
   max = Math.floor(max);
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
-
-
-
-
 
 export { getRandomInt };


### PR DESCRIPTION
- Playwright tests for below scenarios
> Recently shared youtube videos should be rendered correctly with correct link and title
> If there is no youtube movies then there should be a friendly message
> Youtube movies around observation date should be rendered correctly
> If there is no youtube movies around observation date then there should be a friendly message
> Youtube movies around observation date should show markers if the 'show in viewport' checkbox is checked
> Youtube observation date videos should be updated with the observation date change

- Fixed a bug for showing friendly message when there is no videos around given observation date

