### PR TITLE
GOES Name Update

### DIFF
--- a/resources/js/Viewport/HelioviewerViewport.js
+++ b/resources/js/Viewport/HelioviewerViewport.js
@@ -66,6 +66,9 @@ var HelioviewerViewport = Class.extend(
 
         this.dataSources = new Promise((resolve) => {
             callback = function (dataSources) {
+                // CCOR1 is only available on JHelioviewer at this time.
+                try { delete dataSources["GOES"]["CCOR-1"]; } catch (e) {}
+
                 resolve(dataSources);
                 $(document).trigger("datasources-initialized", [dataSources]);
 


### PR DESCRIPTION
# Summary

- Renames GOES-R -> GOES (Needs an API update as well)
- Disables CCOR-1 from the detector dropdown. API updates are needed before this is enabled.

