### PR TITLE
Fix issue page load issue after removing tile layer

### DIFF
--- a/resources/js/Utility/SettingsLoader.js
+++ b/resources/js/Utility/SettingsLoader.js
@@ -51,7 +51,7 @@ var SettingsLoader = (
     },
 
     _patch_goes_r: function(userSettings) {
-        for (const layer of userSettings.settings.state.tileLayers) {
+        for (const layer of Object.values(userSettings.settings.state.tileLayers)) {
             if (layer["Observatory"] === "GOES-R") {
                 layer["Observatory"] = "GOES";
                 layer["uiLabels"][0]["name"] = "GOES";


### PR DESCRIPTION
Problem happens after 2nd layer is removed and page is refreshed/reloaded. Issue was that tileLayers changes from an array to an object and code expected it to be an array.