### PR TITLE
Update YouTube videos in visual glossary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,43 @@ jobs:
         cd tests
         npx playwright test --shard=${{matrix.shardIndex}}/${{matrix.shardTotal}}
 
-    - name: List Directories
-      if: always()
-      run: ls *
-
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: playwright-report-${{matrix.shardIndex}}
-        path: ../tests/playwright-report/
+        name: blob-report-${{matrix.shardIndex}}
+        path: tests/blob-report/
         retention-days: 1
+
+  merge-reports:
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: ${{ !cancelled() }}
+    needs: [playwright-e2e-tests]
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout test code
+      uses: actions/checkout@v4
+      with:
+        repository: 'Helioviewer-Project/helioviewer.org-tests'
+        path: 'tests'
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-blob-reports
+        pattern: blob-report-*
+        merge-multiple: true
+
+    - name: Merge into HTML Report
+      run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-report--attempt-${{ github.run_attempt }}
+        path: playwright-report
+        retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'Helioviewer-Project/helioviewer.org-tests'
-        path: 'tests'
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,13 @@ jobs:
         cd tests
         npx playwright test --shard=${{matrix.shardIndex}}/${{matrix.shardTotal}}
 
+    - name: List Directories
+      if: always()
+      run: ls *
+
     - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report-${{matrix.shardIndex}}
-        path: tests/playwright-report/
+        path: ../tests/playwright-report/
         retention-days: 1

--- a/dialogs/glossary.html
+++ b/dialogs/glossary.html
@@ -153,7 +153,7 @@
     <!--CME-->
     <tr name='cme' class='g-basic g-fe'>
         <td>
-            <iframe class="youtube-player" type="text/html" src="https://www.youtube.com/embed/TWySQHjIRSg" frameborder="0"></iframe>
+            <iframe class="youtube-player" src="https://www.youtube.com/embed/tPR36FI4oGU?si=EB7FFZKRL_YbQGQV" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </td>
         <td>
             <div class='glossary-title'>Coronal Mass Ejection (CME)</div>
@@ -227,7 +227,7 @@
     <!--Flare-->
     <tr name='flare' class='g-basic g-fe'>
         <td>
-            <iframe class="youtube-player" type="text/html" src="https://www.youtube.com/embed/dU0sJm2wgYc" frameborder="0"></iframe>
+            <iframe class="youtube-player" src="https://www.youtube.com/embed/oOXVZo7KikE?si=h4Qiz2kxhDtRXdoO" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </td>
         <td>
             <div class='glossary-title'>Flare</div>
@@ -390,7 +390,7 @@
     <!--Prominence-->
     <tr name='prominence' class='g-basic g-fe'>
         <td>
-            <iframe class="youtube-player" type="text/html" src="https://www.youtube.com/embed/BosmntuHHLo" frameborder="0"></iframe>
+            <iframe class="youtube-player" src="https://www.youtube.com/embed/p_xYcMQe5KA?si=dwfCJ33KhnfaVAO-" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </td>
         <td>
             <div class='glossary-title'>Prominence</div>


### PR DESCRIPTION
# Summary

Videos in the visual glossary are gone because the account hosting the videos is closed.
This change adds new videos posted by the NASA account on YouTube.
