### PR TITLE
Fix movie error

### DIFF
--- a/resources/js/Media/MovieManagerUI.js
+++ b/resources/js/Media/MovieManagerUI.js
@@ -295,14 +295,13 @@ var MovieManagerUI = MediaManagerUI.extend(
 		};
 
 		let failCallback = function (errResp) {
-
-			if (errResp.responseJSON.errno == 12) {
+			const showErrorMessageWhitelist = [12, 16];
+			if (showErrorMessageWhitelist.indexOf(errResp.responseJSON.errno) != -1) {
 				Helioviewer.messageConsole.error(errResp.responseJSON.error);
 			} else {
 				Helioviewer.messageConsole.error("Unable to create movie, please try again later");
 			}
 			console.error(errResp.responseJSON);
-
 		}
 
 		return postJSON("postMovie", params).then(successCallback, failCallback);
@@ -629,7 +628,7 @@ var MovieManagerUI = MediaManagerUI.extend(
 		dateRequested = Date.parseUTCDate(movie.dateRequested);
 
 		if (movie.status === 2 && (new Date) - dateRequested <= 180 * 24 * 60 * 60 * 1000) {
-		
+
 			thumbnail = movie.thumbnail;
 
 			html += "<div style='text-align: center;'>" +

--- a/resources/js/Media/MovieManagerUI.js
+++ b/resources/js/Media/MovieManagerUI.js
@@ -295,9 +295,11 @@ var MovieManagerUI = MediaManagerUI.extend(
 		};
 
 		let failCallback = function (errResp) {
+			// 12 - No images found in requested time range
+			// 16 - Insufficient data found in requested time range
 			const showErrorMessageWhitelist = [12, 16];
 			if (showErrorMessageWhitelist.indexOf(errResp.responseJSON.errno) != -1) {
-				Helioviewer.messageConsole.error(errResp.responseJSON.error);
+				Helioviewer.messageConsole.warn(errResp.responseJSON.error);
 			} else {
 				Helioviewer.messageConsole.error("Unable to create movie, please try again later");
 			}

--- a/resources/js/Media/MovieManagerUI.js
+++ b/resources/js/Media/MovieManagerUI.js
@@ -630,7 +630,6 @@ var MovieManagerUI = MediaManagerUI.extend(
 		dateRequested = Date.parseUTCDate(movie.dateRequested);
 
 		if (movie.status === 2 && (new Date) - dateRequested <= 180 * 24 * 60 * 60 * 1000) {
-
 			thumbnail = movie.thumbnail;
 
 			html += "<div style='text-align: center;'>" +


### PR DESCRIPTION
# Summary

Before patch - Trying to make a movie in a time range without enough images will show:
<img width="323" height="89" alt="image" src="https://github.com/user-attachments/assets/30e12a90-efdf-432a-8598-7a86b3e46bc6" />

After patch, a more informative message is shown indicating there's not enough images:
<img width="326" height="81" alt="image" src="https://github.com/user-attachments/assets/f1b426cb-41cb-4d1e-a39e-44c694748ea0" />

Test run: https://github.com/Helioviewer-Project/helioviewer.org-tests/actions/runs/17947273195
