### PR TITLE
Add fallback to disable 3D mode and show error when 3D is not supported

### DIFF
--- a/resources/js/3d/fallback.jsx
+++ b/resources/js/3d/fallback.jsx
@@ -1,0 +1,15 @@
+import React, { useEffect } from "react";
+
+
+function CanvasFallback() {
+  useEffect(() => {
+    if (Helioviewer.userSettings.get("state.enable3d")) {
+      Helioviewer.messageConsole.error("Your browser does not support WebGL, disabling 3D mode");
+    }
+    Set3DMode(false);
+  }, []);
+
+  return null;
+}
+
+export default CanvasFallback;

--- a/resources/js/3d/fallback.jsx
+++ b/resources/js/3d/fallback.jsx
@@ -3,10 +3,9 @@ import React, { useEffect } from "react";
 // Check if WebGL is actually supported
 function isWebGLSupported() {
   try {
-    const canvas = document.createElement('canvas');
-    return !!(window.WebGLRenderingContext &&
-      (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
-  } catch(e) {
+    const canvas = document.createElement("canvas");
+    return !!(window.WebGLRenderingContext && (canvas.getContext("webgl") || canvas.getContext("experimental-webgl")));
+  } catch (e) {
     return false;
   }
 }

--- a/resources/js/3d/fallback.jsx
+++ b/resources/js/3d/fallback.jsx
@@ -1,12 +1,25 @@
 import React, { useEffect } from "react";
 
+// Check if WebGL is actually supported
+function isWebGLSupported() {
+  try {
+    const canvas = document.createElement('canvas');
+    return !!(window.WebGLRenderingContext &&
+      (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+  } catch(e) {
+    return false;
+  }
+}
 
 function CanvasFallback() {
   useEffect(() => {
-    if (Helioviewer.userSettings.get("state.enable3d")) {
-      Helioviewer.messageConsole.error("Your browser does not support WebGL, disabling 3D mode");
+    // Only run the error handling if WebGL is actually not supported
+    if (!isWebGLSupported()) {
+      if (Helioviewer.userSettings.get("state.enable3d")) {
+        Helioviewer.messageConsole.error("Your browser does not support WebGL, disabling 3D mode");
+      }
+      Set3DMode(false);
     }
-    Set3DMode(false);
   }, []);
 
   return null;

--- a/resources/js/3d/main.jsx
+++ b/resources/js/3d/main.jsx
@@ -58,6 +58,11 @@ function render(root, launched, enabled, layers, date, dollySpeed, coordinator_u
   );
 }
 
+window.Set3DMode = (enabled) => {
+  Helioviewer.userSettings.set("state.enable3d", enabled);
+  $(document).trigger("update-external-datasource-integration");
+}
+
 /**
  * Render the 3D view.
  */

--- a/resources/js/3d/main.jsx
+++ b/resources/js/3d/main.jsx
@@ -61,7 +61,7 @@ function render(root, launched, enabled, layers, date, dollySpeed, coordinator_u
 window.Set3DMode = (enabled) => {
   Helioviewer.userSettings.set("state.enable3d", enabled);
   $(document).trigger("update-external-datasource-integration");
-}
+};
 
 /**
  * Render the 3D view.

--- a/resources/js/3d/viewport3d.jsx
+++ b/resources/js/3d/viewport3d.jsx
@@ -26,10 +26,7 @@ function Viewport3D({ active, visible, layers, date, coordinator, onFail, onLoad
     <>
       <div className="solid-bg"></div>
       {/* If enabled, show the 3D viewport. This can be turned on and off anytime. */}
-      <Canvas
-        style={{ visibility: visible ? "visible" : "hidden" }}
-        orthographic={true}
-        fallback={<CanvasFallback />}>
+      <Canvas style={{ visibility: visible ? "visible" : "hidden" }} orthographic={true} fallback={<CanvasFallback />}>
         {/* Set up the camera controls */}
         <CameraControls ref={controls} dollySpeed={dollySpeed} />
         {/* Render the 3D viewport from the current state */}

--- a/resources/js/3d/viewport3d.jsx
+++ b/resources/js/3d/viewport3d.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import Hv3D from "./helioviewer3d";
 import { CameraControls } from "@react-three/drei";
+import CanvasFallback from "./fallback";
 
 function Viewport3D({ active, visible, layers, date, coordinator, onFail, onLoadStart, onLoadFinish, dollySpeed }) {
   const controls = useRef(null);
@@ -25,7 +26,10 @@ function Viewport3D({ active, visible, layers, date, coordinator, onFail, onLoad
     <>
       <div className="solid-bg"></div>
       {/* If enabled, show the 3D viewport. This can be turned on and off anytime. */}
-      <Canvas style={{ visibility: visible ? "visible" : "hidden" }} orthographic={true}>
+      <Canvas
+        style={{ visibility: visible ? "visible" : "hidden" }}
+        orthographic={true}
+        fallback={<CanvasFallback />}>
         {/* Set up the camera controls */}
         <CameraControls ref={controls} dollySpeed={dollySpeed} />
         {/* Render the 3D viewport from the current state */}


### PR DESCRIPTION
# Summary

Fixes #696 

Add fallback to display error message if 3D is not supported in the browser.

# Checklist

[x] Added desktop tests
[x] Added mobile tests
