### PR TITLE
Prevent 3D sun from snapping back to the center of the viewport when date changes.

### DIFF
--- a/resources/js/3d/components/layers.jsx
+++ b/resources/js/3d/components/layers.jsx
@@ -22,7 +22,7 @@ function getRenderPriority(source, index) {
   return index;
 }
 
-function Layers({ date, layers, coordinator, setCameraPosition, onFail, onLoadStart, onLoadFinish }) {
+function Layers({ date, layers, coordinator, setCameraPosition, getCameraTarget, onFail, onLoadStart, onLoadFinish }) {
   const priorities = layers.map((layer, idx) => getRenderPriority(layer.sourceId, idx));
   // Returns true if the sourceId must be rendered in a plane.
   const isPlane = (sourceId) => PLANE_SOURCES.indexOf(sourceId) !== -1;
@@ -31,14 +31,17 @@ function Layers({ date, layers, coordinator, setCameraPosition, onFail, onLoadSt
   // spheres don't blend with the planes.
   const sceneHasSphereModels = layers.some((layer) => PLANE_SOURCES.indexOf(layer.sourceId) === -1);
 
-  const [targetCameraPosition, setTargetCameraPosition] = useState(new Vector3(0, 0, 100));
+  const [targetCameraPosition, setTargetCameraPosition] = useState({
+    position: new Vector3(0, 0, 100),
+    target: new Vector3(0, 0, 0)
+  });
   const [loadCount, setLoadCount] = useState(0);
 
   useEffect(() => {
     if (loadCount === 0) {
       setCameraPosition(targetCameraPosition);
     }
-  }, [loadCount]);
+  }, [loadCount, targetCameraPosition]);
 
   /** Render each layer. Plus a sphere that holds as a background for the sun. */
   return (
@@ -54,6 +57,7 @@ function Layers({ date, layers, coordinator, setCameraPosition, onFail, onLoadSt
           opacity={layer.visible ? layer.opacity : 0}
           observatory={layer.observatory}
           setCameraPosition={setTargetCameraPosition}
+          getCameraTarget={getCameraTarget}
           useSphereOcclusion={sceneHasSphereModels && isPlane(layer.sourceId)}
           onStartLoad={() => {
             onLoadStart();

--- a/resources/js/3d/components/sun.jsx
+++ b/resources/js/3d/components/sun.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useRef, useState } from "react";
 import { extend, useFrame, useThree } from "@react-three/fiber";
 import { Quality, StaticSun } from "@helioviewer/sun";
 import { SSCWS } from "../coordinates/sscws";
-import { Vector3, Matrix4 } from "three";
+import { Vector3, Matrix4, Quaternion } from "three";
+import * as THREE from "three";
 import Background from "../background";
 import { Horizons } from "../coordinates/horizons";
 extend({ StaticSun });
@@ -108,8 +109,9 @@ function Sun3D({
               setFirstLook(false);
             } else {
               // Compute where the camera needs to be so we're looking at the new
-              // sun from the same perspective.
-              setCameraPosition(computeCameraPosition(originalSunDirection, objectDirection, camera.position, getCameraTarget()));
+              // sun from the same perspective, preserving any pan offset.
+              const currentTarget = getCameraTarget ? getCameraTarget() : new Vector3(0, 0, 0);
+              setCameraPosition(computeCameraPosition(originalSunDirection, objectDirection, camera.position, currentTarget));
             }
             setOriginalSunDirection(objectDirection.clone());
           }
@@ -192,19 +194,16 @@ function computeCameraPosition(originalDirection, newDirection, currentCameraPos
   const origDir = originalDirection.clone().normalize();
   const newDir = newDirection.clone().normalize();
 
-  // Use the current camera position directly
-  const relativePosition = currentCameraPosition.clone();
+  // Calculate the rotation quaternion from original to new direction
+  const quaternion = new Quaternion();
+  quaternion.setFromUnitVectors(origDir, newDir);
 
-  // Create rotation matrices for both directions
-  const originalMatrix = new Matrix4().lookAt(origDir, new Vector3(), new Vector3(0, 1, 0));
-  const newMatrix = new Matrix4().lookAt(newDir, new Vector3(), new Vector3(0, 1, 0));
+  // Create rotation matrix from quaternion
+  const rotationMatrix = new Matrix4().makeRotationFromQuaternion(quaternion);
 
-  // Calculate the rotation from original to new direction
-  const rotationMatrix = new Matrix4().multiplyMatrices(newMatrix, originalMatrix.invert());
-
-  // Apply the rotation to the relative camera position
-  const newCameraPosition = relativePosition.applyMatrix4(rotationMatrix);
-  const newCameraTarget = currentCameraTarget.applyMatrix4(rotationMatrix);
+  // Apply the rotation to both camera position and target
+  const newCameraPosition = currentCameraPosition.clone().applyMatrix4(rotationMatrix);
+  const newCameraTarget = currentCameraTarget.clone().applyMatrix4(rotationMatrix);
 
   return {position: newCameraPosition, target: newCameraTarget};
 }

--- a/resources/js/3d/components/sun.jsx
+++ b/resources/js/3d/components/sun.jsx
@@ -17,6 +17,7 @@ function Sun3D({
   opacity,
   observatory,
   setCameraPosition,
+  getCameraTarget,
   useSphereOcclusion,
   parentReady,
   onStartLoad,
@@ -100,12 +101,15 @@ function Sun3D({
             sunObj.current.getWorldDirection(objectDirection);
             // On first look, set the camera to be right in front of the sun.
             if (firstLook) {
-              setCameraPosition(objectDirection.clone().multiplyScalar(100));
+              setCameraPosition({
+                position: objectDirection.clone().multiplyScalar(100),
+                target: new Vector3(0, 0, 0)
+              });
               setFirstLook(false);
             } else {
               // Compute where the camera needs to be so we're looking at the new
               // sun from the same perspective.
-              setCameraPosition(computeCameraPosition(originalSunDirection, objectDirection, camera.position));
+              setCameraPosition(computeCameraPosition(originalSunDirection, objectDirection, camera.position, getCameraTarget()));
             }
             setOriginalSunDirection(objectDirection.clone());
           }
@@ -183,7 +187,7 @@ function Sun3D({
   );
 }
 
-function computeCameraPosition(originalDirection, newDirection, currentCameraPosition) {
+function computeCameraPosition(originalDirection, newDirection, currentCameraPosition, currentCameraTarget) {
   // Normalize the direction vectors to ensure they are unit vectors
   const origDir = originalDirection.clone().normalize();
   const newDir = newDirection.clone().normalize();
@@ -200,8 +204,9 @@ function computeCameraPosition(originalDirection, newDirection, currentCameraPos
 
   // Apply the rotation to the relative camera position
   const newCameraPosition = relativePosition.applyMatrix4(rotationMatrix);
+  const newCameraTarget = currentCameraTarget.applyMatrix4(rotationMatrix);
 
-  return newCameraPosition;
+  return {position: newCameraPosition, target: newCameraTarget};
 }
 
 export default Sun3D;

--- a/resources/js/3d/helioviewer3d.jsx
+++ b/resources/js/3d/helioviewer3d.jsx
@@ -5,7 +5,7 @@ import { Layers } from "./components/layers";
 /**
  * Renders the current helioviewer state
  */
-function Hv3D({ coordinator, layers, date, setCameraPosition, onFail, onLoadStart, onLoadFinish }) {
+function Hv3D({ coordinator, layers, date, setCameraPosition, getCameraTarget, onFail, onLoadStart, onLoadFinish }) {
   // Disable react 3 fiber automatic rendering by executing useFrame with a
   // non-zero value.
   useFrame(() => {}, 1);
@@ -26,6 +26,7 @@ function Hv3D({ coordinator, layers, date, setCameraPosition, onFail, onLoadStar
       layers={layers}
       coordinator={coordinator}
       setCameraPosition={setCameraPosition}
+      getCameraTarget={getCameraTarget}
       onFail={onFail}
     />
   );

--- a/resources/js/3d/viewport3d.jsx
+++ b/resources/js/3d/viewport3d.jsx
@@ -3,6 +3,7 @@ import { Canvas } from "@react-three/fiber";
 import Hv3D from "./helioviewer3d";
 import { CameraControls } from "@react-three/drei";
 import CanvasFallback from "./fallback";
+import * as THREE from "three";
 
 function Viewport3D({ active, visible, layers, date, coordinator, onFail, onLoadStart, onLoadFinish, dollySpeed }) {
   const controls = useRef(null);
@@ -10,6 +11,20 @@ function Viewport3D({ active, visible, layers, date, coordinator, onFail, onLoad
   useEffect(() => {
     if (controls.current != null) {
       controls.current.zoomTo(150);
+
+      // After any pan/rotation, reset target to (0,0,0) while maintaining the view
+      const onControlEnd = () => {
+        // Set both position and target
+        controls.current.setOrbitPoint(0, 0, 0);
+      };
+
+      controls.current.addEventListener('controlend', onControlEnd);
+
+      return () => {
+        if (controls.current) {
+          controls.current.removeEventListener('controlend', onControlEnd);
+        }
+      };
     }
   }, [controls.current]);
 

--- a/resources/js/3d/viewport3d.jsx
+++ b/resources/js/3d/viewport3d.jsx
@@ -17,8 +17,8 @@ function Viewport3D({ active, visible, layers, date, coordinator, onFail, onLoad
    * Move the camera to the given position
    * @param {Vector3} position
    */
-  const setCameraPosition = (position) => {
-    controls.current.setLookAt(position.x, position.y, position.z, 0, 0, 0);
+  const setCameraPosition = ({position, target}) => {
+    controls.current.setLookAt(position.x, position.y, position.z, target.x, target.y, target.z);
   };
 
   /** Render the 3D canvas */
@@ -39,6 +39,7 @@ function Viewport3D({ active, visible, layers, date, coordinator, onFail, onLoad
             layers={layers}
             date={date}
             setCameraPosition={setCameraPosition}
+            getCameraTarget={() => controls.current.getTarget()}
             onFail={onFail}
           />
         ) : (


### PR DESCRIPTION
# Summary

Fixes #697 

Updates 3D to retain panned offset when date changes instead of snapping the sun back to the center.
Also keeps the center of rotation on the sun after panning.

# Checklist

- [x] Added desktop tests
- [x] Added mobile tests
