### PR TITLE
Fix mobile student.helioviewer.org

### DIFF
--- a/index.php
+++ b/index.php
@@ -41,6 +41,7 @@
         }else if(isset($_GET['output']) && ($_GET['output'] == 'embed' || $_GET['output'] == 'minimal')){
                 $outputType = $_GET['output'];
         }
+	    $is_mobile = !$outputType && isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'],'Phone')|strpos($_SERVER['HTTP_USER_AGENT'],'Android')|strpos($_SERVER['HTTP_USER_AGENT'],'iPad');
 
         if($outputType){ // minimal and embed statistic
                 //Load Config
@@ -138,6 +139,7 @@
 		<link rel="stylesheet" href="/resources/css/youtube.css" />
 		<link rel="stylesheet" href="/resources/css/font-awesome.min.css" />
 		<link rel="stylesheet" href="/resources/css/helioviewer-views.css" />
+		<link rel="stylesheet" href="/resources/css/mobile_minimal_embed.css" />
 	<?php
 	} else {
 	?>
@@ -151,8 +153,7 @@
 	<?php /* "cascading" part of CSS. Which is needed for this 3d.css         */ ?>
 	<link rel="stylesheet" href="/resources/css/3d.css" />
 <?php
-if(isset($_SERVER['HTTP_USER_AGENT'])) {
-	if(strpos($_SERVER['HTTP_USER_AGENT'],'Phone')|strpos($_SERVER['HTTP_USER_AGENT'],'Android')|strpos($_SERVER['HTTP_USER_AGENT'],'iPad')) {
+if($is_mobile) {
 		$mtime = filemtime('resources/lib/responsive/responsive_hv.css');
 		$hvmobcssfiles= <<<MCF
 			<!-- START responsive CSS files -->
@@ -189,7 +190,6 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 			</style>
 	DCH;
 		echo $hvdesktopcsshides;
-	}
 }
 ?>
 	<style id="js-styles"></style>
@@ -1996,8 +1996,7 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 	?>
 
 <?php
-if(isset($_SERVER['HTTP_USER_AGENT'])) {
-	if(strpos($_SERVER['HTTP_USER_AGENT'],'Phone')|strpos($_SERVER['HTTP_USER_AGENT'],'Android')|strpos($_SERVER['HTTP_USER_AGENT'],'iPad')) {
+if($is_mobile) {
 	$hvmobjsfiles= <<<MJF
 	<!-- START responsive JS files -->
 	<script src='/resources/lib/responsive/zeynep1.js'></script>
@@ -2006,7 +2005,6 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 	<!-- END responsive JS files -->
 	MJF;
 	echo $hvmobjsfiles;
-	}
 }
 ?>
 
@@ -2113,7 +2111,7 @@ if(isset($_SERVER['HTTP_USER_AGENT'])) {
 			Helioviewer.messageConsole = new MessageConsole();
 			Helioviewer.outputType = "<?php echo $outputType ? $outputType : "normal"; ?>";
 			Helioviewer.debug = <?php echo $debug ? 'true' : 'false'; ?>;
-			Helioviewer.mobile = <?php echo isset($_SERVER['HTTP_USER_AGENT']) && (strpos($_SERVER['HTTP_USER_AGENT'],'Phone')|strpos($_SERVER['HTTP_USER_AGENT'],'Android')|strpos($_SERVER['HTTP_USER_AGENT'],'iPad')) ? 'true' : 'false'; ?>
+			Helioviewer.mobile = <?php echo $is_mobile ? 'true' : 'false'; ?>
 
 			const loadHelioviewer = (userSettings) => {
 

--- a/index.php
+++ b/index.php
@@ -41,7 +41,8 @@
         }else if(isset($_GET['output']) && ($_GET['output'] == 'embed' || $_GET['output'] == 'minimal')){
                 $outputType = $_GET['output'];
         }
-	    $is_mobile = !$outputType && isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'],'Phone')|strpos($_SERVER['HTTP_USER_AGENT'],'Android')|strpos($_SERVER['HTTP_USER_AGENT'],'iPad');
+		$is_mobile = isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'],'Phone')|strpos($_SERVER['HTTP_USER_AGENT'],'Android')|strpos($_SERVER['HTTP_USER_AGENT'],'iPad');
+	    $is_mobile_view = !$outputType && $is_mobile;
 
         if($outputType){ // minimal and embed statistic
                 //Load Config
@@ -144,6 +145,7 @@
 	} else {
 	?>
 		<link rel="stylesheet" href="/resources/compressed/helioviewer.min.css?v=<?=filemtime('resources/compressed/helioviewer.min.css')?>" />
+		<link rel="stylesheet" href="/resources/css/mobile_minimal_embed.css" />
 	<?php
 	}
 	?>
@@ -153,7 +155,7 @@
 	<?php /* "cascading" part of CSS. Which is needed for this 3d.css         */ ?>
 	<link rel="stylesheet" href="/resources/css/3d.css" />
 <?php
-if($is_mobile) {
+if($is_mobile_view) {
 		$mtime = filemtime('resources/lib/responsive/responsive_hv.css');
 		$hvmobcssfiles= <<<MCF
 			<!-- START responsive CSS files -->
@@ -1548,7 +1550,7 @@ if($is_mobile) {
 				</div>
 			</div>
 
-			<div class="hv-drawer-right user-select-none hv-drawer-date">
+			<div id='js-minimal-datepicker' class="hv-drawer-right user-select-none hv-drawer-date">
 				<div class="drawer-contents" style="display: block;">
 					<div id="k12-accordion-date" class="accordion">
 						<!--<div class="header">
@@ -1996,7 +1998,7 @@ if($is_mobile) {
 	?>
 
 <?php
-if($is_mobile) {
+if($is_mobile_view) {
 	$hvmobjsfiles= <<<MJF
 	<!-- START responsive JS files -->
 	<script src='/resources/lib/responsive/zeynep1.js'></script>
@@ -2111,7 +2113,8 @@ if($is_mobile) {
 			Helioviewer.messageConsole = new MessageConsole();
 			Helioviewer.outputType = "<?php echo $outputType ? $outputType : "normal"; ?>";
 			Helioviewer.debug = <?php echo $debug ? 'true' : 'false'; ?>;
-			Helioviewer.mobile = <?php echo $is_mobile ? 'true' : 'false'; ?>
+			Helioviewer.mobile = <?php echo $is_mobile_view ? 'true' : 'false'; ?>;
+			Helioviewer.mobile_minimal = <?php echo $is_mobile ? 'true' : 'false'; ?>;
 
 			const loadHelioviewer = (userSettings) => {
 

--- a/resources/css/helioviewer-views.css
+++ b/resources/css/helioviewer-views.css
@@ -269,7 +269,7 @@
 
 
 .helioviewer-view-type-minimal .hv-drawer-date{
-	display:block !important;
+	display:block;
 	left:10px;
 	top:10px;
 	position:absolute;

--- a/resources/css/mobile_minimal_embed.css
+++ b/resources/css/mobile_minimal_embed.css
@@ -1,0 +1,59 @@
+@media screen and (max-width: 1024px) {
+    .helioviewer-view-type-minimal {
+        min-width: 100vw;
+        max-width: 100vw;
+    }
+
+    .hv-drawer-right.user-select-none.hv-drawer-date {
+        left: 5%;
+        width: 90%;
+    }
+
+    #hv-drawer-screenshots {
+        /** TODO: Revisit this */
+        display: none !important;
+    }
+
+    #helioviewer-viewport-container-outer {
+        min-width: 100vw;
+        width: 100vw;
+    }
+
+    #message-console {
+        margin-top: 11em;
+    }
+
+    #k12-scale {
+        min-width: 100vw;
+        width: 100vw;
+    }
+}
+
+@media screen and (max-width: 391px) {
+    #time-step-label {
+        margin-right: 0px;
+    }
+
+    #k12-accordion-date .row .field {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    .k12-timeNowBtn {
+        margin-top: 0;
+    }
+
+    #image-layer-select-container {
+        transform: translateY(5px);
+    }
+
+    #image-layer-select {
+        margin-bottom: -8px;
+    }
+
+    #observation-label {
+        margin-top: 0 !important;
+    }
+}

--- a/resources/css/mobile_minimal_embed.css
+++ b/resources/css/mobile_minimal_embed.css
@@ -1,17 +1,60 @@
 @media screen and (max-width: 1024px) {
+    html, body {
+        min-width: 100vw;
+        max-width: 100vw;
+        min-height: 100vh;
+        max-height: 100vh;
+        width: 100vw;
+        height: 100vh;
+    }
+
+  	#toptouchlayer {
+		touch-action: none;
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		z-index: 10;
+	}
+
+    .helioviewer-view-type-minimal #movies-button,
+    .helioviewer-view-type-minimal #screenshots-button,
+    .helioviewer-view-type-minimal #help-button {
+        position: absolute;
+        top: auto;
+        left: auto;
+    }
+
+    .helioviewer-view-type-minimal #movies-button {
+        bottom: 1em;
+        right: 2.5em;
+    }
+
+    .helioviewer-view-type-minimal #screenshots-button {
+        bottom: 1em;
+        right: 1em;
+    }
+
+    .helioviewer-view-type-minimal #help-button {
+        display: none;
+    }
+
+
     .helioviewer-view-type-minimal {
         min-width: 100vw;
         max-width: 100vw;
     }
 
-    .hv-drawer-right.user-select-none.hv-drawer-date {
-        left: 5%;
-        width: 90%;
+    #hv-drawer-movies, #hv-drawer-screenshots {
+        position: fixed;
+        width: 90vw !important;
+        top: 2.5vw;
     }
 
+    .hv-drawer-right.user-select-none.hv-drawer-date,
+    #hv-drawer-movies,
     #hv-drawer-screenshots {
-        /** TODO: Revisit this */
-        display: none !important;
+        left: 5vw;
+        width: 90vw;
     }
 
     #helioviewer-viewport-container-outer {
@@ -26,6 +69,11 @@
     #k12-scale {
         min-width: 100vw;
         width: 100vw;
+    }
+
+    .__react_modal_image__modal_container {
+        width: 100vw !important;
+        height: 100vh !important;
     }
 }
 

--- a/resources/js/HelioviewerWebClient.js
+++ b/resources/js/HelioviewerWebClient.js
@@ -2305,11 +2305,11 @@ var HelioviewerWebClient = HelioviewerClient.extend(
     drawerMoviesClick: function(openNow) {
         var self = this, buttonId = "#movies-button";
 
-        this.closeTabDrawersExcept('#'+this.drawerMovies.attr('id'));
-
         self._movieManagerUI._refresh();
 
-        if ( $(buttonId).hasClass('opened') || openNow === false ) {
+        const openingDrawer = !$(buttonId).hasClass('opened') || openNow === true;
+        const closingDrawer = !openingDrawer || openNow === false;
+        if ( closingDrawer ) {
             self.drawerMovies.css('transition', '');
             $('.drawer-contents', this.drawerMovies).fadeOut(10);
             this.drawerMovies.css('width', 0);
@@ -2318,8 +2318,12 @@ var HelioviewerWebClient = HelioviewerClient.extend(
             this.drawerMovies.css({'display':'none'});
             $(buttonId).removeClass('opened');
             Helioviewer.userSettings.set("state.drawers.#hv-drawer-movies.open", false);
+            // On mobile minimal view, toggle the datepicker when screenshot drawer opens.
+            if (Helioviewer.mobile_minimal) {
+                $('#js-minimal-datepicker').show();
+            }
         }
-        else if ( !$(buttonId).hasClass('opened') || openNow === true ) {
+        else if ( openingDrawer ) {
             self.drawerMovies.css('transition', 'height 500ms');
             this.drawerMovies.css('width', this.drawerMoviesOpenedWidth);
             this.drawerMovies.css('height', this.drawerMoviesOpenedHeight);
@@ -2333,17 +2337,18 @@ var HelioviewerWebClient = HelioviewerClient.extend(
             this.reopenAccordions(this.drawerMovies);
         }
 
+        this.closeTabDrawersExcept('#'+this.drawerMovies.attr('id'), openingDrawer);
         return;
     },
 
     drawerScreenshotsClick: function(openNow) {
         var self = this, buttonId = "#screenshots-button";
 
-        this.closeTabDrawersExcept('#'+this.drawerScreenshots.attr('id'));
-
         self._screenshotManagerUI._refresh();
 
-        if ( $(buttonId).hasClass('opened') || openNow === false ) {
+        const openingDrawer = !$(buttonId).hasClass('opened') || openNow === true;
+        const closingDrawer = !openingDrawer || openNow === false;
+        if ( closingDrawer ) {
 
             self.drawerScreenshots.css('transition', '');
             $('.drawer-contents', this.drawerScreenshots).fadeOut(10);
@@ -2353,8 +2358,12 @@ var HelioviewerWebClient = HelioviewerClient.extend(
             this.drawerScreenshots.css({'display':'none'});
             $(buttonId).removeClass('opened');
             Helioviewer.userSettings.set("state.drawers.#hv-drawer-screenshots.open", false);
+            // On mobile minimal view, toggle the datepicker when screenshot drawer opens.
+            if (Helioviewer.mobile_minimal) {
+                $('#js-minimal-datepicker').show();
+            }
         }
-        else if ( !$(buttonId).hasClass('opened') || openNow === true ) {
+        else if ( openingDrawer ) {
             self.drawerScreenshots.css('transition', 'height 500ms');
             this.drawerScreenshots.css('width', this.drawerScreenshotsOpenedWidth);
             this.drawerScreenshots.css('height', this.drawerScreenshotsOpenedHeight);
@@ -2368,6 +2377,7 @@ var HelioviewerWebClient = HelioviewerClient.extend(
             this.reopenAccordions(this.drawerScreenshots);
         }
 
+        this.closeTabDrawersExcept('#'+this.drawerScreenshots.attr('id'), openingDrawer);
         return;
     },
 
@@ -2519,8 +2529,14 @@ var HelioviewerWebClient = HelioviewerClient.extend(
         return;
     },
 
-    closeTabDrawersExcept: function (drawerId) {
+    closeTabDrawersExcept: function (drawerId, isOpening) {
         var self = this;
+
+        // On mobile minimal view, toggle the datepicker when screenshot drawer opens.
+        if (Helioviewer.mobile_minimal) {
+            isOpening ? $('#js-minimal-datepicker').hide() :
+                        $('#js-minimal-datepicker').show();
+        }
 
         $.each( this.tabbedDrawers, function (i, drawer) {
             if ( drawer != drawerId ) {


### PR DESCRIPTION
# Summary

Fixes mobile student.helioviewer.org

- Add CSS for mobile/minimal view
- Add logic to add js variable for mobile minimal view, separate from mobile default view.
- Add logic to properly show/hide selected controls.

See preview below of how it works after this patch. Previously the page was completely broken on mobile.

Before:
<img width="360" height="702" alt="image" src="https://github.com/user-attachments/assets/a5e8da5d-a9c7-46e3-b10d-a7c1e106be81" />

After:
<video src="https://github.com/user-attachments/assets/602643df-2eb8-41da-b716-8889ff588327"/>

